### PR TITLE
feat(keyboard): End voice input when releasing long-pressed space

### DIFF
--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/BaseKeyboard.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/BaseKeyboard.kt
@@ -1270,6 +1270,7 @@ abstract class BaseKeyboard(
     ) {
         view.setOnClickListener(null)
         view.setOnLongClickListener(null)
+        view.onLongPressReleaseListener = null
         view.repeatEnabled = false
         view.onRepeatListener = null
         view.doubleTapEnabled = false
@@ -1298,6 +1299,11 @@ abstract class BaseKeyboard(
                     view.setOnLongClickListener { _ ->
                         onAction(it.action)
                         true
+                    }
+                    if (it.action is KeyAction.SpaceLongPressAction) {
+                        view.onLongPressReleaseListener = {
+                            onAction(KeyAction.SpaceLongPressReleaseAction)
+                        }
                     }
                 }
                 is KeyDef.Behavior.Repeat -> {

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/CommonKeyActionListener.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/CommonKeyActionListener.kt
@@ -31,6 +31,7 @@ import org.fcitx.fcitx5.android.input.keyboard.KeyAction.PickerSwitchAction
 import org.fcitx.fcitx5.android.input.keyboard.KeyAction.QuickPhraseAction
 import org.fcitx.fcitx5.android.input.keyboard.KeyAction.ShowInputMethodPickerAction
 import org.fcitx.fcitx5.android.input.keyboard.KeyAction.SpaceLongPressAction
+import org.fcitx.fcitx5.android.input.keyboard.KeyAction.SpaceLongPressReleaseAction
 import org.fcitx.fcitx5.android.input.keyboard.KeyAction.SymAction
 import org.fcitx.fcitx5.android.input.keyboard.KeyAction.UnicodeAction
 import org.fcitx.fcitx5.android.input.picker.PickerWindow
@@ -221,6 +222,11 @@ class CommonKeyActionListener :
                         }
                         SpaceLongPressBehavior.ShowPicker -> showInputMethodPicker()
                         SpaceLongPressBehavior.VoiceInput -> switchToVoiceInput()
+                    }
+                }
+                is SpaceLongPressReleaseAction -> {
+                    if (spaceKeyLongPressBehavior == SpaceLongPressBehavior.VoiceInput) {
+                        VoiceInputProviderManager.finish(service)
                     }
                 }
                 else -> {}

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/CustomGestureView.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/CustomGestureView.kt
@@ -85,6 +85,7 @@ open class CustomGestureView(ctx: Context) : FrameLayout(ctx) {
     private var maybeDoubleTap = false
 
     var onDoubleTapListener: ((View) -> Unit)? = null
+    var onLongPressReleaseListener: ((View) -> Unit)? = null
     var onRepeatListener: ((View) -> Unit)? = null
     var onGestureListener: OnGestureListener? = null
 
@@ -182,6 +183,9 @@ open class CustomGestureView(ctx: Context) : FrameLayout(ctx) {
                 isPressed = false
                 InputFeedbacks.hapticFeedback(this, longPress = true, keyUp = true)
                 dispatchGestureEvent(GestureType.Up, event.x, event.y)
+                if (longPressTriggered) {
+                    onLongPressReleaseListener?.invoke(this)
+                }
                 val shouldPerformClick = !(touchMovedOutside ||
                         longPressTriggered ||
                         repeatStarted ||
@@ -233,6 +237,9 @@ open class CustomGestureView(ctx: Context) : FrameLayout(ctx) {
             MotionEvent.ACTION_CANCEL -> {
                 isPressed = false
                 dispatchGestureEvent(GestureType.Up, event.x, event.y)
+                if (longPressTriggered) {
+                    onLongPressReleaseListener?.invoke(this)
+                }
                 resetState()
                 // reset double tap state on cancel
                 if (doubleTapEnabled) {

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyAction.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyAction.kt
@@ -133,6 +133,8 @@ sealed class KeyAction {
 
     data object SpaceLongPressAction : KeyAction()
 
+    data object SpaceLongPressReleaseAction : KeyAction()
+
     data class LayerSwitchAction(
         val mode: LayerSwitchMode,
         val target: String

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/voice/VoiceInputProviderManager.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/voice/VoiceInputProviderManager.kt
@@ -343,7 +343,9 @@ object VoiceInputProviderManager {
                 logI("provider ready")
                 service.lifecycleScope.launch {
                     onProviderReady(service, onLevel, onError)
-                    onReady()
+                    if (!finishing) {
+                        onReady()
+                    }
                 }
             }
 
@@ -701,6 +703,10 @@ object VoiceInputProviderManager {
                     .onFailure { Timber.w(it, "stop pre-roll capture") }
                 activeCapture = null
             }
+            if (finishing) {
+                sendEndStream(service)
+                return
+            }
             startCapture(service, onLevel, onError)
             return
         }
@@ -715,6 +721,9 @@ object VoiceInputProviderManager {
         logI("pre-roll flush: packets=${drained.size}")
         drained.forEach { queue.trySend(it) }
         activeAudioFeedJob = launchAudioFeedJob(service, queue)
+        if (finishing) {
+            finishAudioStream(service)
+        }
     }
 
     private fun launchAudioFeedJob(
@@ -797,7 +806,11 @@ object VoiceInputProviderManager {
         }
     }
 
-    private fun finish(context: Context = appContext) {
+    fun finish(context: Context = appContext) {
+        if (!isActive()) {
+            logI("finish ignored: no active session")
+            return
+        }
         if (floatingFallbackActive) {
             stopFloatingFallback(context)
             return
@@ -818,9 +831,21 @@ object VoiceInputProviderManager {
         activeCapture?.let {
             runCatching { it.stop() }.onFailure { Timber.w(it, "capture stop") }
         }
-        activeCapture = null
-        resetPreRoll()
 
+        if (activeAudioFeedQueue == null) {
+            synchronized(preRollLock) {
+                preRollActive = false
+            }
+            logI("finish deferred until provider is ready")
+            return
+        }
+
+        resetPreRoll()
+        activeCapture = null
+        finishAudioStream(context)
+    }
+
+    private fun finishAudioStream(context: Context) {
         val queue = activeAudioFeedQueue
         val feedJob = activeAudioFeedJob
         val scope = (context as? FcitxInputMethodService)?.lifecycleScope


### PR DESCRIPTION
实现功能： 当前空格键长按行为是语音输入的时候，当说话完成时，需要再次按下空格才能结束录音，希望调整成松开空格即可结束录音，节省一次手部动作

由Codex-GPT-5.5 vibe code而成，暂未验证改动是否生效，提供一个思路

# 思路：
核心思路是把空格长按拆成两个事件：
- SpaceLongPressAction：长按触发，开始语音输入
- SpaceLongPressReleaseAction：同一次触摸松手/取消时触发，结束语音输入

# 改动点

- `CustomGestureView.kt`
  - 新增 `onLongPressReleaseListener`
  - 在长按已经触发后，收到 `ACTION_UP` / `ACTION_CANCEL` 时回调 release listener

- `KeyAction.kt`
  - 新增 `SpaceLongPressReleaseAction`
  - 用于表示“空格长按后的松手事件”

- `BaseKeyboard.kt`
  - 为 `SpaceLongPressAction` 绑定松手回调
  - 空格长按触发后，松手时派发 `SpaceLongPressReleaseAction`

- `CommonKeyActionListener.kt`
  - 在 `spaceKeyLongPressBehavior == VoiceInput` 时处理 `SpaceLongPressReleaseAction`
  - 松开空格时调用 `VoiceInputProviderManager.finish(service)` 结束语音输入

- `VoiceInputProviderManager.kt`
  - 将 `finish()` 暴露给键盘事件层调用
  - `finish()` 走正常 `endStream()` 收尾流程，保留最终识别结果提交
  - 处理 provider 还未 ready 时松手的情况：先停止采集，等 provider ready 后 flush pre-roll 音频并发送 `endStream()`
  - 避免已经进入 finishing 后再把 UI 状态切回“正在聆听”