### PR TITLE
perf: cache keyboard rows and skip redundant layout reloads

### DIFF
--- a/app/src/main/java/org/fcitx/fcitx5/android/input/bar/ui/idle/NumberRow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/bar/ui/idle/NumberRow.kt
@@ -20,6 +20,8 @@ import kotlin.math.abs
 @SuppressLint("ViewConstructor")
 class NumberRow(ctx: Context, theme: Theme) : BaseKeyboard(ctx, theme, ::Layout, { null }) {
 
+    override fun currentLayoutSignature(): String = "NumberRow"
+
     private var gestureStartEvent: MotionEvent? = null
     private var collapseGestureTriggered: Boolean = false
 

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/candidates/expanded/ExpandedCandidateLayout.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/candidates/expanded/ExpandedCandidateLayout.kt
@@ -43,6 +43,8 @@ import splitties.views.imageResource
 class ExpandedCandidateLayout(context: Context, theme: Theme) : ConstraintLayout(context) {
 
     class Keyboard(context: Context, theme: Theme) : BaseKeyboard(context, theme, ::Layout, { null }) {
+        override fun currentLayoutSignature(): String = "ExpandedCandidate"
+
         companion object {
             const val UpBtnLabel = "U"
             const val DownBtnLabel = "D"

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/BaseKeyboard.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/BaseKeyboard.kt
@@ -181,8 +181,15 @@ abstract class BaseKeyboard(
     // press (macrokey "layer to" or shift-based language switching) is the dominant source
     // of input latency; reusing prebuilt rows skips the expensive view construction entirely.
     // NOTE: must be declared before the init block, which triggers the first reloadLayout().
-    private val reusableRowsCache = HashMap<String, ReusableRows>()
+    private val reusableRowsCache = object : LinkedHashMap<String, ReusableRows>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: Map.Entry<String, ReusableRows>): Boolean =
+            size > MAX_CACHED_ROWS
+    }
     private var lastRowsSignature: String? = null
+
+    private companion object {
+        const val MAX_CACHED_ROWS = 12
+    }
 
     private var lastSplitLandscapeState = false
 
@@ -221,10 +228,11 @@ abstract class BaseKeyboard(
 
     /**
      * Signature identifying the semantic keyboard content (layer, input method, sub mode, ...).
-     * Subclasses rendering different KeyDef sets must override this so cached rows are never
-     * reused across different layouts.
+     * Every subclass must implement this so cached rows are never reused across different
+     * layouts. For static layouts a constant identifying the layout is sufficient; layouts
+     * that change at runtime must derive the signature from the resolved layout inputs.
      */
-    protected open fun currentLayoutSignature(): String = ""
+    protected abstract fun currentLayoutSignature(): String
 
     private fun currentRowsSignature(splitKeyboard: Boolean): String {
         val prefs = ThemeManager.prefs
@@ -242,6 +250,8 @@ abstract class BaseKeyboard(
                 .append(",").append(prefs.keyHorizontalMarginLandscape.getValue())
             append("|vMargins:").append(prefs.keyVerticalMargin.getValue())
                 .append(",").append(prefs.keyVerticalMarginLandscape.getValue())
+            append("|expandKeys:").append(AppPrefs.getInstance().keyboard.expandKeypressArea.getValue())
+            append("|splitGap:").append(splitKeyboardManager.getSplitGapPercent())
             append("|fontRefresh:").append(FontProviders.needsRefresh())
         }
     }
@@ -250,20 +260,31 @@ abstract class BaseKeyboard(
      * Re-register keyboard-level state for a reused row set. KeyViews keep the gesture
      * configuration they were built with, so only the registries rebuilt on every reload
      * (space keys, compose-aware keys) need to be repopulated.
+     *
+     * Validate every row before changing either registry. This keeps a stale cache entry
+     * from leaving partially registered state behind when the caller falls back to a rebuild.
      */
-    private fun registerReusableRowState(rows: List<List<KeyDef>>, containers: List<ConstraintLayout>) {
+    private fun registerReusableRowState(rows: List<List<KeyDef>>, containers: List<ConstraintLayout>): Boolean {
+        val validatedRows = ArrayList<List<Pair<KeyDef, KeyView>>>(rows.size)
         rows.forEachIndexed { rowIndex, rowDefs ->
-            val container = containers.getOrNull(rowIndex) ?: return@forEachIndexed
+            val container = containers.getOrNull(rowIndex) ?: return false
             val keyViews = container.children.mapNotNull { it as? KeyView }.toList()
+            if (keyViews.size != rowDefs.size) return false
+            val validatedRow = ArrayList<Pair<KeyDef, KeyView>>(rowDefs.size)
             rowDefs.forEachIndexed { keyIndex, def ->
-                val keyView = keyViews.getOrNull(keyIndex) ?: return@forEachIndexed
-                // Only register when the reused view really belongs to this def;
-                // when in doubt, skip to avoid wiring the wrong def to the view.
+                val keyView = keyViews[keyIndex]
                 val matchesDef = keyView.def === def.appearance ||
                     def.composeOverride?.appearance === keyView.def
-                if (!matchesDef) return@forEachIndexed
-                if (def is SpaceKey || def is MiniSpaceKey) {
-                    if (!spaceKeys.contains(keyView)) spaceKeys.add(keyView)
+                if (!matchesDef) return false
+                validatedRow += def to keyView
+            }
+            validatedRows += validatedRow
+        }
+
+        validatedRows.forEach { row ->
+            row.forEach { (def, keyView) ->
+                if (def is SpaceKey && !spaceKeys.contains(keyView)) {
+                    spaceKeys.add(keyView)
                 }
                 if (def.composeOverride != null) {
                     composeAwareKeys += ComposeAwareKey(
@@ -280,6 +301,7 @@ abstract class BaseKeyboard(
                 }
             }
         }
+        return true
     }
 
     protected open fun reloadLayout() {
@@ -312,8 +334,9 @@ abstract class BaseKeyboard(
         // Reuse only when the cached rows were built from the exact same KeyDef instances;
         // providers that re-create defs on every call (e.g. the builtin fallback layout)
         // then rebuild instead of silently re-registering mismatched state.
-        keyRows = if (cachedRows != null && cachedRows.defs === rows) {
+        keyRows = if (cachedRows != null && cachedRows.defs === rows &&
             registerReusableRowState(rows, cachedRows.containers)
+        ) {
             cachedRows.containers
         } else {
             val built = rows.map { row ->
@@ -326,9 +349,6 @@ abstract class BaseKeyboard(
                 } else {
                     buildRegularRow(row, keyViews)
                 }
-            }
-            if (reusableRowsCache.size >= 12) {
-                reusableRowsCache.clear()
             }
             reusableRowsCache[rowsSignature] = ReusableRows(rows, built)
             built

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/BaseKeyboard.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/BaseKeyboard.kt
@@ -171,6 +171,19 @@ abstract class BaseKeyboard(
 
     private val composeAwareKeys = mutableListOf<ComposeAwareKey>()
 
+    private data class ReusableRows(
+        val defs: List<List<KeyDef>>,
+        val containers: List<ConstraintLayout>
+    )
+
+    // Rows built by a previous reload are cached per layout/style signature and reused on
+    // the next reload with the same signature. Rebuilding the whole view tree on every key
+    // press (macrokey "layer to" or shift-based language switching) is the dominant source
+    // of input latency; reusing prebuilt rows skips the expensive view construction entirely.
+    // NOTE: must be declared before the init block, which triggers the first reloadLayout().
+    private val reusableRowsCache = HashMap<String, ReusableRows>()
+    private var lastRowsSignature: String? = null
+
     private var lastSplitLandscapeState = false
 
     @Keep
@@ -206,8 +219,74 @@ abstract class BaseKeyboard(
         splitKeyboardManager.registerListener(splitStateChangeListener)
     }
 
+    /**
+     * Signature identifying the semantic keyboard content (layer, input method, sub mode, ...).
+     * Subclasses rendering different KeyDef sets must override this so cached rows are never
+     * reused across different layouts.
+     */
+    protected open fun currentLayoutSignature(): String = ""
+
+    private fun currentRowsSignature(splitKeyboard: Boolean): String {
+        val prefs = ThemeManager.prefs
+        return buildString {
+            append(currentLayoutSignature())
+            append("|split:").append(splitKeyboard)
+            append("|orient:").append(resources.configuration.orientation)
+            append("|composing:").append(composing)
+            append("|gapScale:").append(horizontalGapScale)
+            append("|border:").append(prefs.keyBorder.getValue()).append(prefs.keyBorderStroke.getValue())
+            append("|ripple:").append(prefs.keyRippleEffect.getValue())
+            append("|radius:").append(prefs.keyRadius.getValue())
+            append("|oval:").append(prefs.specialKeyOvalShape.getValue())
+            append("|hMargins:").append(prefs.keyHorizontalMargin.getValue())
+                .append(",").append(prefs.keyHorizontalMarginLandscape.getValue())
+            append("|vMargins:").append(prefs.keyVerticalMargin.getValue())
+                .append(",").append(prefs.keyVerticalMarginLandscape.getValue())
+            append("|fontRefresh:").append(FontProviders.needsRefresh())
+        }
+    }
+
+    /**
+     * Re-register keyboard-level state for a reused row set. KeyViews keep the gesture
+     * configuration they were built with, so only the registries rebuilt on every reload
+     * (space keys, compose-aware keys) need to be repopulated.
+     */
+    private fun registerReusableRowState(rows: List<List<KeyDef>>, containers: List<ConstraintLayout>) {
+        rows.forEachIndexed { rowIndex, rowDefs ->
+            val container = containers.getOrNull(rowIndex) ?: return@forEachIndexed
+            val keyViews = container.children.mapNotNull { it as? KeyView }.toList()
+            rowDefs.forEachIndexed { keyIndex, def ->
+                val keyView = keyViews.getOrNull(keyIndex) ?: return@forEachIndexed
+                // Only register when the reused view really belongs to this def;
+                // when in doubt, skip to avoid wiring the wrong def to the view.
+                val matchesDef = keyView.def === def.appearance ||
+                    def.composeOverride?.appearance === keyView.def
+                if (!matchesDef) return@forEachIndexed
+                if (def is SpaceKey || def is MiniSpaceKey) {
+                    if (!spaceKeys.contains(keyView)) spaceKeys.add(keyView)
+                }
+                if (def.composeOverride != null) {
+                    composeAwareKeys += ComposeAwareKey(
+                        def,
+                        keyView,
+                        GestureBaseline(
+                            swipeEnabled = keyView.swipeEnabled,
+                            swipeRepeatEnabled = keyView.swipeRepeatEnabled,
+                            swipeThresholdX = keyView.swipeThresholdX,
+                            swipeThresholdY = keyView.swipeThresholdY,
+                            onGestureListener = keyView.onGestureListener
+                        )
+                    )
+                }
+            }
+        }
+    }
+
     protected open fun reloadLayout() {
         val startedAt = SystemClock.elapsedRealtime()
+        // Detach ripple-occluder listeners from views of the outgoing tree before it is
+        // discarded or cached; the ripple view itself is recreated on every reload.
+        keyboardWaterRippleView?.setOccluders(emptyList())
         removeAllViews()
         auxBarInnerContainer = null
         auxBarScrollableAdapter = null
@@ -228,17 +307,33 @@ abstract class BaseKeyboard(
         val rows = keyLayout
         rowHeightPercents = resolveRowHeightPercents(rows)
 
-        keyRows = rows.map { row ->
-            val keyViews = row.map(::createKeyView).apply {
-                // Batch apply fontset mappings for all key labels.
-                forEach(::applyConfiguredFonts)
+        val rowsSignature = currentRowsSignature(splitKeyboard)
+        val cachedRows = reusableRowsCache[rowsSignature]
+        // Reuse only when the cached rows were built from the exact same KeyDef instances;
+        // providers that re-create defs on every call (e.g. the builtin fallback layout)
+        // then rebuild instead of silently re-registering mismatched state.
+        keyRows = if (cachedRows != null && cachedRows.defs === rows) {
+            registerReusableRowState(rows, cachedRows.containers)
+            cachedRows.containers
+        } else {
+            val built = rows.map { row ->
+                val keyViews = row.map(::createKeyView).apply {
+                    // Batch apply fontset mappings for all key labels.
+                    forEach(::applyConfiguredFonts)
+                }
+                if (splitKeyboard) {
+                    buildSplitRow(row, keyViews)
+                } else {
+                    buildRegularRow(row, keyViews)
+                }
             }
-            if (splitKeyboard) {
-                buildSplitRow(row, keyViews)
-            } else {
-                buildRegularRow(row, keyViews)
+            if (reusableRowsCache.size >= 12) {
+                reusableRowsCache.clear()
             }
+            reusableRowsCache[rowsSignature] = ReusableRows(rows, built)
+            built
         }
+        lastRowsSignature = rowsSignature
 
         val auxBarConfig = auxBarConfig
         if (auxBarConfig != null && auxBarConfig.position != AuxBarPosition.AbovePreedit) {
@@ -901,6 +996,16 @@ abstract class BaseKeyboard(
     }
 
     /**
+     * Drop all cached row sets. Call before a reload that must rebuild rows even though
+     * the layout/style signature did not change (e.g. font set refresh whose flag was
+     * already consumed).
+     */
+    fun clearReusableRowsCache() {
+        reusableRowsCache.clear()
+        lastRowsSignature = null
+    }
+
+    /**
      * Lightweight style refresh, updates colors without rebuilding layout
      */
     fun refreshStyleLight() {
@@ -1099,6 +1204,11 @@ abstract class BaseKeyboard(
     open fun onCompositionStateChanged(composing: Boolean) {
         if (this.composing == composing) return
         this.composing = composing
+        // The attached rows are about to be mutated in place (compose-aware views get
+        // recreated). Evict the cache entry holding them so a later reload can never
+        // reuse rows that were modified under a different composition state.
+        lastRowsSignature?.let { reusableRowsCache.remove(it) }
+        lastRowsSignature = null
         data class PendingUpdate(
             val item: ComposeAwareKey,
             val activeDef: KeyDef,

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
@@ -151,6 +151,10 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
      */
     fun checkAndApplyFontRefresh() {
         if (org.fcitx.fcitx5.android.input.font.FontProviders.checkAndClearRefreshFlag()) {
+            // The refresh flag is consumed above, so the rows cache would otherwise
+            // reuse rows built with the previous font set. Clear it first so
+            // refreshAllKeyboards() rebuilds rows and re-applies configured fonts.
+            keyboards.values.forEach { it.clearReusableRowsCache() }
             refreshAllKeyboards()
         }
     }
@@ -223,7 +227,8 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
     fun switchLayout(
         to: String,
         remember: Boolean = true,
-        inheritTextHeight: Boolean = true
+        inheritTextHeight: Boolean = true,
+        notifyHeightChange: Boolean = true
     ) {
         val target = to.ifEmpty { lastSymbolType }
         ContextCompat.getMainExecutor(service).execute {
@@ -247,12 +252,16 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
                         updateCompositionState()
                     }
                     applyAuxActions(lastAuxActions)
-                    service.inputView?.onKeyboardHeightSourceChanged()
+                    if (notifyHeightChange) {
+                        service.inputView?.onKeyboardHeightSourceChanged()
+                    }
                     return@execute
                 }
                 detachCurrentLayout()
                 attachLayout(target)
-                service.inputView?.onKeyboardHeightSourceChanged()
+                if (notifyHeightChange) {
+                    service.inputView?.onKeyboardHeightSourceChanged()
+                }
                 if (windowManager.isAttached(this)) {
                     notifyBarLayoutChanged()
                 }
@@ -324,11 +333,15 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
 
     private fun handleLayerSwitchAction(action: KeyAction.LayerSwitchAction) {
         val hadAuxBarConfig = TextKeyboard.getAuxBarConfig() != null
+        val heightBefore = TextKeyboard.currentLayoutHeightPercentOverride()
         val resolved = TextKeyboard.resolveLayerTargetKey(action.target)
         if (resolved == null) {
             if (action.mode == KeyAction.LayerSwitchMode.TO) {
                 clearAllLayerOverrides()
-                service.inputView?.onKeyboardHeightSourceChanged()
+                val heightAfter = TextKeyboard.currentLayoutHeightPercentOverride()
+                if (heightBefore != heightAfter) {
+                    service.inputView?.onKeyboardHeightSourceChanged()
+                }
             }
             return
         }
@@ -343,7 +356,12 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
         }
         applyEffectiveTextLayer()
         refreshNoConfigAuxBarFallback(hadAuxBarConfig)
-        switchLayout(TextKeyboard.Name, remember = false)
+        val heightAfter = TextKeyboard.currentLayoutHeightPercentOverride()
+        switchLayout(
+            TextKeyboard.Name,
+            remember = false,
+            notifyHeightChange = heightBefore != heightAfter
+        )
     }
 
     fun switchLayer(mode: KeyAction.LayerSwitchMode, target: String) {
@@ -369,9 +387,16 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
     }
 
     override fun onImeUpdate(ime: InputMethodEntry) {
+        val heightBefore = TextKeyboard.currentLayoutHeightPercentOverride()
         clearAllLayerOverrides()
         currentKeyboard?.onInputMethodUpdate(ime)
-        service.inputView?.onKeyboardHeightSourceChanged()
+        val heightAfter = TextKeyboard.currentLayoutHeightPercentOverride()
+        // Avoid the IME-window height update path when the resolved keyboard height did not
+        // actually change. This runs on every input method/sub-mode update (e.g. pressing
+        // shift to toggle language) and used to be an unconditional, expensive window relayout.
+        if (heightBefore != heightAfter) {
+            service.inputView?.onKeyboardHeightSourceChanged()
+        }
     }
 
     override fun onPunctuationUpdate(mapping: Map<String, String>) {

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/NumberKeyboard.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/NumberKeyboard.kt
@@ -19,6 +19,8 @@ class NumberKeyboard(
     theme: Theme,
 ) : BaseKeyboard(context, theme, ::Layout, { null }) {
 
+    override fun currentLayoutSignature(): String = Name
+
     companion object {
         const val Name = "Number"
 

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/TextKeyboard.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/TextKeyboard.kt
@@ -139,11 +139,11 @@ class TextKeyboard(
             val normalized = layoutKey?.trim()?.takeIf { it.isNotEmpty() }
             if (forcedLayoutKey == normalized) return
             forcedLayoutKey = normalized
-            cachedKeyDefLayouts.clear()
             val living = attachedKeyboards.mapNotNull { it.get() }
             attachedKeyboards.removeAll { it.get() == null }
             living.forEach { keyboard ->
                 keyboard.refreshStyle()
+                keyboard.markLayoutSignatureApplied()
                 ime?.let { keyboard.updateSpaceLabel(it) }
             }
         }
@@ -842,6 +842,90 @@ class TextKeyboard(
     private var lastLayoutSignature: String? = null
     private fun transformPunctuation(p: String) = punctuationMapping.getOrDefault(p, p)
 
+    private fun selectedLayoutArray(ime: InputMethodEntry): JsonArray? {
+        val json = textLayoutJson ?: return null
+        forcedLayoutKey?.let { forced ->
+            return findLayoutElementByKey(json, forced)
+        }
+        val imeLayoutElement = json[ime.uniqueName] ?: json[ime.displayName]
+        if (imeLayoutElement != null) {
+            val subModeLabel = ime.subMode.run { label.ifEmpty { name.ifEmpty { "" } } }
+            val schemaId = schemaIdFromSubModeIcon(ime.subMode.icon)
+            val subModeName = ime.subMode.name
+            val subModeLayoutElement = resolveSubModeLayoutElement(
+                imeLayoutElement = imeLayoutElement,
+                subModeLabel = subModeLabel,
+                schemaId = schemaId,
+                subModeName = subModeName
+            )
+            // Note: parenthesize explicitly — `?:` binds looser than `?.`,
+            // so without grouping a non-null first operand would NOT return here
+            // and the function would fall through to the "default" lookup (and
+            // wrongly report null for flat layouts that have no "default" key).
+            val layoutArray = parseLayoutArray(subModeLayoutElement)
+                ?: parseLayoutArray(imeLayoutElement)
+            if (layoutArray != null) return layoutArray
+        }
+        return parseLayoutArray(json["default"])
+    }
+
+    private fun layoutArrayUsesSubMode(rows: JsonArray): Boolean {
+        for (rowElement in rows) {
+            val row = rowElement as? JsonArray ?: return true
+            for (keyElement in row) {
+                val key = keyElement as? JsonObject ?: return true
+                if (key["displayText"] is JsonObject) return true
+                val composeOverride = key["composeOverride"] as? JsonObject
+                if (composeOverride?.get("displayText") is JsonObject) return true
+            }
+        }
+        return false
+    }
+
+    private var cachedUsesSubModeKey: String? = null
+    private var cachedUsesSubModeValue = false
+
+    /**
+     * Whether the resolved layout renders sub-mode-specific content. Runs on every layout
+     * signature computation, so memoize the scan result per (layer, ime, sub mode, layout
+     * file revision); the layout JSON is only invalidated when [lastRawModified] changes.
+     */
+    private fun layoutUsesSubMode(ime: InputMethodEntry): Boolean {
+        val cacheKey = buildString {
+            append(forcedLayoutKey ?: "")
+            append('|').append(ime.uniqueName)
+            append('|').append(ime.displayName)
+            append('|').append(ime.subMode.label)
+            append('|').append(ime.subMode.name)
+            append('|').append(ime.subMode.icon)
+            append('|').append(lastRawModified)
+        }
+        if (cachedUsesSubModeKey == cacheKey) return cachedUsesSubModeValue
+        val result = layoutUsesSubModeInternal(ime)
+        cachedUsesSubModeKey = cacheKey
+        cachedUsesSubModeValue = result
+        return result
+    }
+
+    private fun layoutUsesSubModeInternal(ime: InputMethodEntry): Boolean {
+        val json = textLayoutJson ?: return true
+        forcedLayoutKey?.let { forced ->
+            val rows = findLayoutElementByKey(json, forced) ?: return true
+            return layoutArrayUsesSubMode(rows)
+        }
+        val baseElement = json[ime.uniqueName] ?: json[ime.displayName]
+        if (baseElement is JsonObject) {
+            val hasSubModeLayout = baseElement.keys.any { key ->
+                key != LAYOUT_META_KEY &&
+                    key != "default" &&
+                    key != "" &&
+                    parseLayoutArray(baseElement[key]) != null
+            }
+            if (hasSubModeLayout) return true
+        }
+        return layoutArrayUsesSubMode(selectedLayoutArray(ime) ?: return true)
+    }
+
     private fun layoutSignature(ime: InputMethodEntry): String {
         val json = textLayoutJson
         val layoutSource = when {
@@ -851,7 +935,93 @@ class TextKeyboard(
         }
         val subModeLabel = ime.subMode.run { label.ifEmpty { name.ifEmpty { "" } } }
         val forced = forcedLayoutKey ?: ""
-        return "$layoutSource|$subModeLabel|$forced|$lastRawModified"
+        return buildString {
+            append(layoutSource)
+            if (layoutUsesSubMode(ime)) {
+                append('|')
+                append(subModeLabel)
+            }
+            append('|')
+            append(forced)
+            append('|')
+            append(lastRawModified)
+        }
+    }
+
+    internal fun markLayoutSignatureApplied() {
+        val currentIme = TextKeyboard.ime ?: return
+        lastLayoutSignature = layoutSignature(currentIme)
+    }
+
+    /**
+     * Signature describing which KeyDef layout the keyboard currently renders.
+     * It mirrors the branch logic of [getLayout] so rows cached by BaseKeyboard are only
+     * reused when the resolved layout (layer / input method / sub mode / layout file) is
+     * actually the same.
+     */
+    protected override fun currentLayoutSignature(): String {
+        val json = textLayoutJson
+        val currentIme = ime
+        val showLangSwitch = AppPrefs.getInstance().keyboard.showLangSwitchKey.getValue()
+        val imeName = currentIme?.uniqueName
+        val displayName = currentIme?.displayName
+        val subModeLabel = currentIme?.subMode?.label ?: ""
+        val subModeName = currentIme?.subMode?.name ?: ""
+        val schemaId = schemaIdFromSubModeIcon(currentIme?.subMode?.icon ?: "")
+        // Only distinguish by sub mode when the layout actually renders sub-mode-specific
+        // content; for flat layouts the KeyDef output is identical across sub modes and
+        // including this context would invalidate the row cache on every shift toggle.
+        val usesSubMode = currentIme?.let { layoutUsesSubMode(it) } ?: false
+        val contextKey = if (usesSubMode) {
+            listOf(schemaId, subModeLabel, subModeName)
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .distinct()
+                .joinToString(separator = "|")
+                .ifEmpty { "none" }
+        } else {
+            "none"
+        }
+        val forced = forcedLayoutKey
+        val branch = when {
+            forced != null && json != null && findLayoutElementByKey(json, forced) != null ->
+                "forced:$forced"
+            imeName != null && json != null &&
+                (json[imeName] != null || displayName?.let { json[it] } != null) -> {
+                val imeLayoutElement = json[imeName] ?: displayName?.let { json[it] }
+                if (imeLayoutElement != null) {
+                    val subModeLayoutElement = resolveSubModeLayoutElement(
+                        imeLayoutElement = imeLayoutElement,
+                        subModeLabel = subModeLabel,
+                        schemaId = schemaId,
+                        subModeName = subModeName
+                    )
+                    if (parseLayoutArray(subModeLayoutElement) != null) {
+                        val matchedSubModeKey = (imeLayoutElement as? JsonObject)?.let { obj ->
+                            subModeCandidates(subModeLabel, schemaId, subModeName)
+                                .firstOrNull { obj[it] != null }
+                        } ?: "default"
+                        "ime:$imeName:$matchedSubModeKey"
+                    } else if (json["default"]?.let { parseLayoutArray(it) } != null) {
+                        "default"
+                    } else {
+                        "builtin"
+                    }
+                } else if (json["default"]?.let { parseLayoutArray(it) } != null) {
+                    "default"
+                } else {
+                    "builtin"
+                }
+            }
+            json?.get("default")?.let { parseLayoutArray(it) } != null -> "default"
+            else -> "builtin"
+        }
+        return buildString {
+            append(branch)
+            append('|').append(showLangSwitch)
+            append('|').append(contextKey)
+            append('|').append(lastRawModified)
+        }
     }
 
     override fun onAction(action: KeyAction, source: KeyActionListener.Source) {

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/picker/PickerLayout.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/picker/PickerLayout.kt
@@ -41,6 +41,8 @@ class PickerLayout(context: Context, theme: Theme, switchKey: KeyDef) :
         )}
     ) {
 
+        override fun currentLayoutSignature(): String = "Picker"
+
         class PunctuationKey(val symbol: String) : KeyDef(
             Appearance.Text(
                 displayText = symbol,


### PR DESCRIPTION
## 问题背景

每次按键（macrokey“切层”、Shift 切换中英文）都会把整个键盘视图树拆掉重建。同一布局在小米 14 上一次 `reloadLayout` 只要 5~28ms，
而在一加 12（ColorOS 16）上要 121~561ms，导致切层和中英文切换有明显的零点几秒卡顿。

本 PR 的核心思路：按“布局/样式签名”把已构建好的行容器缓存起来，后续重建直接复用，跳过昂贵的视图构造；
同时去掉几个冗余的重建/窗口重布局触发点。

## 改动内容

- 按布局/样式签名缓存已构建的行容器，后续 reload 直接复用。
  - 组合输入状态变化（`onCompositionStateChanged` 会原地重建 compose 视图）之前，先失效当前签名对应的缓存条目，
    保证被原地修改过的行永远不会以过期外观被复用；
  - 字体热刷新（`checkAndApplyFontRefresh` 消费刷新标志后）之前，先清空行缓存，保证新字体真正被重新应用；
  - 仅当缓存行确实由同一批 `KeyDef` 实例构建时才复用；对每次调用都重建 KeyDef 的提供方（如无布局文件时的内置兜底布局），
    回退为整树重建，而不是静默跳过状态重注册。
- 抽出 `selectedLayoutArray` 并显式分组，避开 `?:` 与 `?.` 的优先级陷阱——扁平布局在中英文切换之间保持稳定签名，
    shift 切中英文不再触发任何重建。
- 切层后记录已应用的布局签名，跳过紧随其后的第二次冗余重建。
- 只有键盘高度真正变化时才通知 IME 窗口更新高度，避免每次按键都走昂贵的窗口重布局路径。
- 子模式布局扫描结果按布局修订号记忆化。

## 实测数据

一加 12（ColorOS 16），与小米 14 上相同的自定义布局：

- 修改前：每次切层/切换中英文都会触发两次完整 `reloadLayout`，每次 121~561ms；
- 修改后：切层 8~16ms（reuse=true，仅每层首次进入构建一次），shift 切中英文完全不重建。

## 测试矩阵

- [x] ColorOS 16（一加 12）：切层、Shift 切中英文——真机验证，日志确认（reuse=true，8~16ms）
- [x] MIUI（小米 14）：同一布局——真机验证
- [x] 字体热加载（设置里改字体/字号后回到输入法界面）
- [x] 键盘打开状态下在布局编辑器里保存
- [x] 分屏键盘开关
- [x] 主题切换
- [x] 横竖屏切换

## 备注

- 与先前讨论一致：独立 Shift 按键保持时长维持上游原样（150ms），本 PR 不包含该行为变更。
- 高度通知的 gating 逻辑上只影响高度依赖的路径，但 `updateKeyboardSize` 还附带单手模式/悬浮条等副作用，建议合入前按需真机复核。