### PR TITLE
feat(键盘): 支持选择自定义数字输入布局、数字键编辑及物理小键盘键值保留

### DIFF
--- a/app/src/main/java/org/fcitx/fcitx5/android/core/CapabilityFlag.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/core/CapabilityFlag.kt
@@ -105,7 +105,10 @@ value class CapabilityFlags constructor(val flags: ULong) {
                 }
             }
             info.inputType.let {
-                when (it and InputType.TYPE_MASK_CLASS) {
+                val inputClass = it and InputType.TYPE_MASK_CLASS
+                val numericPasswordVariation =
+                    (it and InputType.TYPE_MASK_VARIATION) == InputType.TYPE_NUMBER_VARIATION_PASSWORD
+                when (inputClass) {
                     InputType.TYPE_NULL -> {
                         flags -= CapabilityFlag.Preedit
                         flags += CapabilityFlag.NoSpellCheck
@@ -174,6 +177,14 @@ value class CapabilityFlags constructor(val flags: ULong) {
                             }
                         }
                     }
+                }
+                // PIN-style numeric password fields (number or phone class carrying the
+                // number-password variation) suppress candidates the same way as text
+                // password fields: fcitx empties the candidate bar for the Password flag.
+                if ((inputClass == InputType.TYPE_CLASS_NUMBER ||
+                        inputClass == InputType.TYPE_CLASS_PHONE) && numericPasswordVariation
+                ) {
+                    flags += CapabilityFlag.Password
                 }
             }
             return CapabilityFlags(flags)

--- a/app/src/main/java/org/fcitx/fcitx5/android/core/KeySym.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/core/KeySym.kt
@@ -15,7 +15,33 @@ value class KeySym(val sym: Int) {
     override fun toString() = "0x" + sym.toString(16).padStart(4, '0')
 
     companion object {
+        private fun numpadKeySym(keyCode: Int): Int? = when (keyCode) {
+            KeyEvent.KEYCODE_NUMPAD_0 -> FcitxKeyMapping.FcitxKey_KP_0
+            KeyEvent.KEYCODE_NUMPAD_1 -> FcitxKeyMapping.FcitxKey_KP_1
+            KeyEvent.KEYCODE_NUMPAD_2 -> FcitxKeyMapping.FcitxKey_KP_2
+            KeyEvent.KEYCODE_NUMPAD_3 -> FcitxKeyMapping.FcitxKey_KP_3
+            KeyEvent.KEYCODE_NUMPAD_4 -> FcitxKeyMapping.FcitxKey_KP_4
+            KeyEvent.KEYCODE_NUMPAD_5 -> FcitxKeyMapping.FcitxKey_KP_5
+            KeyEvent.KEYCODE_NUMPAD_6 -> FcitxKeyMapping.FcitxKey_KP_6
+            KeyEvent.KEYCODE_NUMPAD_7 -> FcitxKeyMapping.FcitxKey_KP_7
+            KeyEvent.KEYCODE_NUMPAD_8 -> FcitxKeyMapping.FcitxKey_KP_8
+            KeyEvent.KEYCODE_NUMPAD_9 -> FcitxKeyMapping.FcitxKey_KP_9
+            KeyEvent.KEYCODE_NUMPAD_ENTER -> FcitxKeyMapping.FcitxKey_KP_Enter
+            KeyEvent.KEYCODE_NUMPAD_ADD -> FcitxKeyMapping.FcitxKey_KP_Add
+            KeyEvent.KEYCODE_NUMPAD_SUBTRACT -> FcitxKeyMapping.FcitxKey_KP_Subtract
+            KeyEvent.KEYCODE_NUMPAD_MULTIPLY -> FcitxKeyMapping.FcitxKey_KP_Multiply
+            KeyEvent.KEYCODE_NUMPAD_DIVIDE -> FcitxKeyMapping.FcitxKey_KP_Divide
+            KeyEvent.KEYCODE_NUMPAD_DOT -> FcitxKeyMapping.FcitxKey_KP_Decimal
+            KeyEvent.KEYCODE_NUMPAD_COMMA -> FcitxKeyMapping.FcitxKey_KP_Separator
+            KeyEvent.KEYCODE_NUMPAD_EQUALS -> FcitxKeyMapping.FcitxKey_KP_Equal
+            else -> null
+        }
+
         fun fromKeyEvent(event: KeyEvent): KeySym? {
+            // Preserve keypad semantics even when Android also exposes a Unicode character
+            // such as '0' or '.'. Otherwise physical keypad keys become ordinary Rime keys.
+            numpadKeySym(event.keyCode)?.let { return KeySym(it) }
+
             val charCode = event.unicodeChar
             // try charCode first, allow upper and lower case characters generating different KeySym
             if (charCode != 0 &&

--- a/app/src/main/java/org/fcitx/fcitx5/android/data/prefs/AppPrefs.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/data/prefs/AppPrefs.kt
@@ -245,6 +245,15 @@ class AppPrefs(private val sharedPreferences: SharedPreferences) {
             "text_keyboard_layout_profile",
             "default"
         ).apply { register() }
+        /**
+         * 数字输入框使用的自定义布局键（可为任意布局名或 ime:submode，如 rime:wanxiang）。
+         * 留空表示使用内置数字键盘。仅存于应用设置，与布局文件解耦。
+         */
+        val numericLayoutOverride = ManagedPreference.PString(
+            sharedPreferences,
+            "numeric_layout_override",
+            ""
+        ).apply { register() }
         val langSwitchKeyBehavior = enumList(
             R.string.lang_switch_key_behavior,
             "lang_switch_key_behavior",

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/FcitxInputMethodService.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/FcitxInputMethodService.kt
@@ -104,6 +104,13 @@ import splitties.resources.styledColor
 import timber.log.Timber
 import kotlin.math.max
 
+/**
+ * All numpad key codes, from [KeyEvent.KEYCODE_NUMPAD_0] to [KeyEvent.KEYCODE_NUMPAD_RIGHT_PAREN].
+ * For these keys the simulated key events always carry [KeyEvent.META_NUM_LOCK_ON] so that
+ * Android KeyCharacterMap resolves the digit/symbol characters instead of navigation keys.
+ */
+private val NUMPAD_KEYCODE_RANGE = KeyEvent.KEYCODE_NUMPAD_0..KeyEvent.KEYCODE_NUMPAD_RIGHT_PAREN
+
 class FcitxInputMethodService : LifecycleInputMethodService() {
 
     internal lateinit var fcitx: FcitxConnection
@@ -1267,10 +1274,15 @@ class FcitxInputMethodService : LifecycleInputMethodService() {
         }
     }
 
-    private fun simulatedMetaState(): Int {
+    private fun simulatedMetaState(keyCode: Int): Int {
         var metaState = 0
         if (simulatedCapsLockOn) metaState = metaState or KeyEvent.META_CAPS_LOCK_ON
-        if (simulatedNumLockOn) metaState = metaState or KeyEvent.META_NUM_LOCK_ON
+        // Num lock is always treated as ON for numpad keys from the simulated keyboard,
+        // so that Android KeyCharacterMap produces the correct digit/symbol unicode
+        // characters instead of converting them to navigation keys.
+        if (simulatedNumLockOn || keyCode in NUMPAD_KEYCODE_RANGE) {
+            metaState = metaState or KeyEvent.META_NUM_LOCK_ON
+        }
         if (simulatedShiftPressedCount > 0) metaState = metaState or KeyEvent.META_SHIFT_ON
         if (simulatedCtrlPressedCount > 0) metaState = metaState or KeyEvent.META_CTRL_ON
         if (simulatedAltPressedCount > 0) metaState = metaState or KeyEvent.META_ALT_ON
@@ -1297,7 +1309,7 @@ class FcitxInputMethodService : LifecycleInputMethodService() {
                 action,
                 keyCode,
                 0,
-                simulatedMetaState(),
+                simulatedMetaState(keyCode),
                 KeyCharacterMap.VIRTUAL_KEYBOARD,
                 scanCode,
                 KeyEvent.FLAG_SOFT_KEYBOARD or KeyEvent.FLAG_KEEP_TOUCH_MODE
@@ -1319,7 +1331,7 @@ class FcitxInputMethodService : LifecycleInputMethodService() {
         } else if (action == KeyEvent.ACTION_UP) {
             updateSimulatedModifierCount(keyCode, action)
         }
-        val metaState = simulatedMetaState()
+        val metaState = simulatedMetaState(keyCode)
         // Use InputDevice.SOURCE_KEYBOARD so the system uses the physical keyboard KeyCharacterMap
         // This makes function keys (F1-F12) return unicodeChar = 0 and follow the keyCodeToSym path
         val event = KeyEvent(

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/BaseKeyboard.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/BaseKeyboard.kt
@@ -282,7 +282,7 @@ abstract class BaseKeyboard(
 
         validatedRows.forEach { row ->
             row.forEach { (def, keyView) ->
-                if (def is SpaceKey && !spaceKeys.contains(keyView)) {
+                if ((def is SpaceKey || def is MiniSpaceKey) && !spaceKeys.contains(keyView)) {
                     spaceKeys.add(keyView)
                 }
                 if (def.composeOverride != null) {
@@ -1115,7 +1115,7 @@ abstract class BaseKeyboard(
                 is ReturnKey -> InputFeedbacks.SoundEffect.Return
                 else -> InputFeedbacks.SoundEffect.Standard
             }
-            if (def is SpaceKey) {
+            if (def is SpaceKey || def is MiniSpaceKey) {
                 spaceKeys.add(this)
                 swipeEnabled = spaceSwipeMoveCursor.getValue()
                 swipeRepeatEnabled = true

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyDefPreset.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyDefPreset.kt
@@ -569,13 +569,25 @@ class TextPickerSwitchKey(
 )
 
 class MiniSpaceKey(
-    percentWidth: Float = 0.15f
+    percentWidth: Float = 0.15f,
+    textColor: Int? = null,
+    textColorMonet: String? = null,
+    backgroundColor: Int? = null,
+    backgroundColorMonet: String? = null,
+    shadowColor: Int? = null,
+    shadowColorMonet: String? = null
 ) : KeyDef(
     Appearance.Image(
         src = R.drawable.ic_baseline_space_bar_24,
         percentWidth = percentWidth,
         variant = Variant.Alternative,
-        viewId = R.id.button_mini_space
+        viewId = R.id.button_mini_space,
+        textColor = textColor,
+        textColorMonet = textColorMonet,
+        backgroundColor = backgroundColor,
+        backgroundColorMonet = backgroundColorMonet,
+        shadowColor = shadowColor,
+        shadowColorMonet = shadowColorMonet
     ),
     setOf(
         Behavior.Press(KeyAction.SymAction(KeySym(FcitxKeyMapping.FcitxKey_space)))
@@ -588,13 +600,25 @@ class NumPadKey(
     val sym: Int,
     textSize: Float = 16f,
     percentWidth: Float = 0.1f,
-    variant: Variant = Variant.Normal
+    variant: Variant = Variant.Normal,
+    textColor: Int? = null,
+    textColorMonet: String? = null,
+    backgroundColor: Int? = null,
+    backgroundColorMonet: String? = null,
+    shadowColor: Int? = null,
+    shadowColorMonet: String? = null
 ) : KeyDef(
     Appearance.Text(
         displayText,
         textSize = textSize,
         percentWidth = percentWidth,
-        variant = variant
+        variant = variant,
+        textColor = textColor,
+        textColorMonet = textColorMonet,
+        backgroundColor = backgroundColor,
+        backgroundColorMonet = backgroundColorMonet,
+        shadowColor = shadowColor,
+        shadowColorMonet = shadowColorMonet
     ),
     setOf(
         Behavior.Press(KeyAction.SymAction(KeySym(sym), NumLockState))

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyDefPreset.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyDefPreset.kt
@@ -568,10 +568,12 @@ class TextPickerSwitchKey(
     )
 )
 
-class MiniSpaceKey : KeyDef(
+class MiniSpaceKey(
+    percentWidth: Float = 0.15f
+) : KeyDef(
     Appearance.Image(
         src = R.drawable.ic_baseline_space_bar_24,
-        percentWidth = 0.15f,
+        percentWidth = percentWidth,
         variant = Variant.Alternative,
         viewId = R.id.button_mini_space
     ),

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
@@ -395,13 +395,27 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
     }
 
     override fun onStartInput(info: EditorInfo, capFlags: CapabilityFlags) {
-        clearAllLayerOverrides()
+        // Clear latched/one-shot layer state and the BACK layer history; the forced layout
+        // slot is updated in one pass by TextKeyboard.setNumericLayoutKey below.
+        latchedLayerKey = null
+        oneShotLayerKey = null
+        layerHistory.clear()
+        noConfigAuxBarFallbackActive = false
         preeditEmpty = true
         candidateEmpty = true
         composingState = false
-        val targetLayout = when (info.inputType and InputType.TYPE_MASK_CLASS) {
-            InputType.TYPE_CLASS_NUMBER -> NumberKeyboard.Name
-            InputType.TYPE_CLASS_PHONE -> NumberKeyboard.Name
+        val inputClass = info.inputType and InputType.TYPE_MASK_CLASS
+        val isNumericClass = inputClass == InputType.TYPE_CLASS_NUMBER ||
+            inputClass == InputType.TYPE_CLASS_PHONE
+        // Numeric editors short-circuit the built-in number keyboard when the app
+        // preference "numeric_layout_override" names a resolvable custom layout. PIN-style
+        // numeric password fields are included; their candidate bar stays empty via the
+        // Password capability flag, mirroring text password fields.
+        val numericLayoutKey = if (isNumericClass) TextKeyboard.resolveNumericLayoutKey() else null
+        TextKeyboard.setNumericLayoutKey(numericLayoutKey)
+        val targetLayout = when {
+            numericLayoutKey != null -> TextKeyboard.Name
+            isNumericClass -> NumberKeyboard.Name
             else -> TextKeyboard.Name
         }
         switchLayout(targetLayout, remember = false, inheritTextHeight = false)

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
@@ -57,6 +57,16 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
         refreshCurrentKeyboard()
     }
 
+    init {
+        TextKeyboard.setNumericLayoutFallbackTarget(this)
+    }
+
+    internal fun fallbackToNumberKeyboard() {
+        if (currentKeyboardName == TextKeyboard.Name) {
+            switchLayout(NumberKeyboard.Name, remember = false, inheritTextHeight = false)
+        }
+    }
+
     companion object : EssentialWindow.Key {
         private const val MAX_LAYER_HISTORY = 8
     }
@@ -135,7 +145,14 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
      * Call this when split keyboard settings (gap, threshold, enabled) change.
      */
     fun refreshAllKeyboards() {
+        // A layout profile switch can invalidate the numeric-input override resolved at the
+        // last onStartInput. Drop it first so the refresh below does not render the stale
+        // (or now-different) layout, and fall back to the built-in number keyboard.
+        val droppedOverride = TextKeyboard.revalidateNumericLayoutOverride()
         keyboards.values.forEach { it.refreshStyle() }
+        if (droppedOverride && currentKeyboardName == TextKeyboard.Name) {
+            switchLayout(NumberKeyboard.Name, remember = false, inheritTextHeight = false)
+        }
         reapplyReturnKeyDrawable()
     }
 

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
@@ -262,11 +262,21 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
                 target = TextKeyboard.Name
                 TextKeyboard.activateManualNumericLayout(override)
             }
-        } else if (target == TextKeyboard.Name && fromUserKey && TextKeyboard.isNumericLayoutActive()) {
-            // An explicit key in the numeric layout targets the text keyboard (e.g. an
-            // "ABC"-style LayoutSwitchKey in the custom numeric layout). Release the
-            // override for the rest of the session so the normal text keyboard shows.
-            TextKeyboard.dismissNumericLayoutOverride()
+        } else if (target == TextKeyboard.Name && fromUserKey) {
+            // An explicit user key targeting the text keyboard (e.g. an "ABC"-style
+            // LayoutSwitchKey) resets latched/one-shot layers so the normal text keyboard
+            // shows again even when a MacroKey layer switch is currently latched, and
+            // releases any numeric override for the rest of the session.
+            latchedLayerKey = null
+            oneShotLayerKey = null
+            layerHistory.clear()
+            noConfigAuxBarFallbackActive = false
+            applyEffectiveTextLayer()
+            if (TextKeyboard.isNumericLayoutActive()) {
+                TextKeyboard.dismissNumericLayoutOverride()
+            } else {
+                TextKeyboard.releaseManualNumericLayout()
+            }
         } else if (target == TextKeyboard.Name) {
             TextKeyboard.releaseManualNumericLayout()
         }

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
@@ -41,7 +41,7 @@ import splitties.views.dsl.core.lParams
 import splitties.views.dsl.core.matchParent
 
 class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), EssentialWindow,
-    InputBroadcastReceiver {
+    InputBroadcastReceiver, NumericLayoutFallbackListener {
 
     private val service by manager.inputMethodService()
     private val fcitx by manager.fcitx()
@@ -61,7 +61,7 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
         TextKeyboard.setNumericLayoutFallbackTarget(this)
     }
 
-    internal fun fallbackToNumberKeyboard() {
+    override fun onNumericLayoutOverrideInvalidated() {
         if (currentKeyboardName == TextKeyboard.Name) {
             switchLayout(NumberKeyboard.Name, remember = false, inheritTextHeight = false)
         }
@@ -112,7 +112,6 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
     private var oneShotLayerKey: String? = null
     private val layerHistory = ArrayDeque<String>()
     private var noConfigAuxBarFallbackActive = false
-    private var manualNumericOverride = false
     private var companionHeightPercentOverride: Int? = null
     private var companionHeightPxOverride: Int? = null
 
@@ -148,11 +147,8 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
         // A layout profile switch can invalidate the numeric-input override resolved at the
         // last onStartInput. Drop it first so the refresh below does not render the stale
         // (or now-different) layout, and fall back to the built-in number keyboard.
-        val droppedOverride = TextKeyboard.revalidateNumericLayoutOverride()
+        TextKeyboard.handleLayoutSourceChanged()
         keyboards.values.forEach { it.refreshStyle() }
-        if (droppedOverride && currentKeyboardName == TextKeyboard.Name) {
-            switchLayout(NumberKeyboard.Name, remember = false, inheritTextHeight = false)
-        }
         reapplyReturnKeyDrawable()
     }
 
@@ -264,19 +260,15 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
             val override = TextKeyboard.resolveNumericLayoutKey()
             if (override != null) {
                 target = TextKeyboard.Name
-                if (!TextKeyboard.isNumericLayoutActive()) {
-                    manualNumericOverride = true
-                }
-                TextKeyboard.setForcedLayoutKey(override)
+                TextKeyboard.activateManualNumericLayout(override)
             }
         } else if (target == TextKeyboard.Name && fromUserKey && TextKeyboard.isNumericLayoutActive()) {
             // An explicit key in the numeric layout targets the text keyboard (e.g. an
             // "ABC"-style LayoutSwitchKey in the custom numeric layout). Release the
             // override for the rest of the session so the normal text keyboard shows.
             TextKeyboard.dismissNumericLayoutOverride()
-        } else if (target == TextKeyboard.Name && manualNumericOverride) {
-            manualNumericOverride = false
-            TextKeyboard.clearForcedLayoutKey()
+        } else if (target == TextKeyboard.Name) {
+            TextKeyboard.releaseManualNumericLayout()
         }
         ContextCompat.getMainExecutor(service).execute {
             if (target == TextKeyboard.Name || target == NumberKeyboard.Name) {
@@ -449,7 +441,6 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
         oneShotLayerKey = null
         layerHistory.clear()
         noConfigAuxBarFallbackActive = false
-        manualNumericOverride = false
         preeditEmpty = true
         candidateEmpty = true
         composingState = false

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
@@ -165,7 +165,7 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
 
     private val keyActionListener = KeyActionListener { it, source ->
         when (it) {
-            is KeyAction.LayoutSwitchAction -> switchLayout(it.act)
+            is KeyAction.LayoutSwitchAction -> switchLayout(it.act, fromUserKey = true)
             is KeyAction.LayerSwitchAction -> handleLayerSwitchAction(it)
             is KeyAction.AuxBarTrigger -> {
                 val actionId = it.edgeId
@@ -232,9 +232,11 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
         to: String,
         remember: Boolean = true,
         inheritTextHeight: Boolean = true,
-        notifyHeightChange: Boolean = true
+        notifyHeightChange: Boolean = true,
+        fromUserKey: Boolean = false
     ) {
-        var target = to.ifEmpty { lastSymbolType }
+        val requestedTarget = to.ifEmpty { lastSymbolType }
+        var target = requestedTarget
         // The built-in NumberKeyboard is short-circuited by the configured numeric layout
         // no matter how it is reached: a numeric editor via onStartInput, a manual
         // LayoutSwitchKey, the symbol picker numpad button, or a preset/macro key targeting
@@ -250,6 +252,11 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
                 }
                 TextKeyboard.setForcedLayoutKey(override)
             }
+        } else if (target == TextKeyboard.Name && fromUserKey && TextKeyboard.isNumericLayoutActive()) {
+            // An explicit key in the numeric layout targets the text keyboard (e.g. an
+            // "ABC"-style LayoutSwitchKey in the custom numeric layout). Release the
+            // override for the rest of the session so the normal text keyboard shows.
+            TextKeyboard.dismissNumericLayoutOverride()
         } else if (target == TextKeyboard.Name && manualNumericOverride) {
             manualNumericOverride = false
             TextKeyboard.clearForcedLayoutKey()
@@ -266,8 +273,12 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
                 if (target != TextKeyboard.Name) {
                     noConfigAuxBarFallbackActive = false
                 }
-                if (remember && target != TextKeyboard.Name) {
-                    lastSymbolType = target
+                // A request for the built-in Number keyboard may be redirected to the text
+                // keyboard by the numeric layout override. Remember the requested target so
+                // the "?123" key still returns to the same (overridden) number keyboard.
+                val rememberTarget = if (target == TextKeyboard.Name) requestedTarget else target
+                if (remember && rememberTarget != TextKeyboard.Name) {
+                    lastSymbolType = rememberTarget
                 }
                 if (target == currentKeyboardName) {
                     if (target == TextKeyboard.Name) {

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
@@ -102,6 +102,7 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
     private var oneShotLayerKey: String? = null
     private val layerHistory = ArrayDeque<String>()
     private var noConfigAuxBarFallbackActive = false
+    private var manualNumericOverride = false
     private var companionHeightPercentOverride: Int? = null
     private var companionHeightPxOverride: Int? = null
 
@@ -233,7 +234,26 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
         inheritTextHeight: Boolean = true,
         notifyHeightChange: Boolean = true
     ) {
-        val target = to.ifEmpty { lastSymbolType }
+        var target = to.ifEmpty { lastSymbolType }
+        // The built-in NumberKeyboard is short-circuited by the configured numeric layout
+        // no matter how it is reached: a numeric editor via onStartInput, a manual
+        // LayoutSwitchKey, the symbol picker numpad button, or a preset/macro key targeting
+        // the Number keyboard. In a numeric editor session the override is sticky; a manual
+        // switch from a text session is remembered so switching back to Text restores the
+        // normal text keyboard.
+        if (target == NumberKeyboard.Name) {
+            val override = TextKeyboard.resolveNumericLayoutKey()
+            if (override != null) {
+                target = TextKeyboard.Name
+                if (!TextKeyboard.isNumericLayoutActive()) {
+                    manualNumericOverride = true
+                }
+                TextKeyboard.setForcedLayoutKey(override)
+            }
+        } else if (target == TextKeyboard.Name && manualNumericOverride) {
+            manualNumericOverride = false
+            TextKeyboard.clearForcedLayoutKey()
+        }
         ContextCompat.getMainExecutor(service).execute {
             if (target == TextKeyboard.Name || target == NumberKeyboard.Name) {
                 if (target == TextKeyboard.Name) {
@@ -401,6 +421,7 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
         oneShotLayerKey = null
         layerHistory.clear()
         noConfigAuxBarFallbackActive = false
+        manualNumericOverride = false
         preeditEmpty = true
         candidateEmpty = true
         composingState = false

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
@@ -277,9 +277,11 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
             } else {
                 TextKeyboard.releaseManualNumericLayout()
             }
-        } else if (target == TextKeyboard.Name) {
-            TextKeyboard.releaseManualNumericLayout()
         }
+        // Note: an internal Text -> Text switch (layer relayout, one-shot consumption,
+        // onStartInput) must NOT release the manual numeric layout here: the layer latch
+        // was applied moments before via applyEffectiveTextLayer and releasing would
+        // clobber it back to the session fallback.
         ContextCompat.getMainExecutor(service).execute {
             if (target == TextKeyboard.Name || target == NumberKeyboard.Name) {
                 if (target == TextKeyboard.Name) {

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/NumericLayoutOverrideController.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/NumericLayoutOverrideController.kt
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * SPDX-FileCopyrightText: Copyright 2026 Fcitx5 for Android Contributors
+ */
+package org.fcitx.fcitx5.android.input.keyboard
+
+/**
+ * Owns the session numeric override and the temporarily forced layer.
+ * The keyboard view remains responsible for applying state changes to attached views.
+ */
+internal class NumericLayoutOverrideController {
+    var sessionKey: String? = null
+        private set
+    var forcedKey: String? = null
+        private set
+    var manual: Boolean = false
+        private set
+
+    fun beginSession(key: String?) {
+        sessionKey = key
+        forcedKey = key
+        manual = false
+    }
+
+    fun force(key: String?) {
+        forcedKey = key?.trim()?.takeIf { it.isNotEmpty() } ?: sessionKey
+    }
+
+    fun activateManual(key: String): Boolean {
+        val wasActive = sessionKey != null
+        if (!wasActive) manual = true
+        forcedKey = key
+        return wasActive
+    }
+
+    fun releaseManual(): Boolean {
+        if (!manual) return false
+        manual = false
+        forcedKey = sessionKey
+        return true
+    }
+
+    fun dismiss() {
+        sessionKey = null
+        forcedKey = null
+        manual = false
+    }
+
+    fun revalidate(resolved: String?): Boolean {
+        val current = sessionKey ?: return false
+        if (resolved == current) return false
+        sessionKey = resolved
+        if (forcedKey == current) forcedKey = resolved
+        return resolved == null
+    }
+}

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/TextKeyboard.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/TextKeyboard.kt
@@ -193,6 +193,26 @@ class TextKeyboard(
         @Synchronized
         fun isNumericLayoutActive(): Boolean = numericLayoutKey != null
 
+        /**
+         * Release the numeric-input layout override for the rest of the current session,
+         * clearing both the session slot and the forced slot. Used when the user explicitly
+         * switches back to the text keyboard (e.g. an "ABC"-style key in the custom numeric
+         * layout). Unlike [clearForcedLayoutKey], this does not fall back to the numeric
+         * layout, so input method updates will not silently pull the editor back onto it.
+         * A new [onStartInput] call re-applies the override via [setNumericLayoutKey].
+         */
+        @Synchronized
+        fun dismissNumericLayoutOverride() {
+            if (numericLayoutKey == null && forcedLayoutKey == null) return
+            numericLayoutKey = null
+            forcedLayoutKey = null
+            forEachAttachedKeyboard { keyboard ->
+                keyboard.refreshStyle()
+                keyboard.markLayoutSignatureApplied()
+                ime?.let { keyboard.updateSpaceLabel(it) }
+            }
+        }
+
         @Synchronized
         private fun forEachAttachedKeyboard(action: (TextKeyboard) -> Unit) {
             val living = attachedKeyboards.mapNotNull { it.get() }

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/TextKeyboard.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/TextKeyboard.kt
@@ -75,11 +75,19 @@ class TextKeyboard(
             cachedRawLayoutJson = null
             lastRawModified = 0L
             lastRawLayoutFile = null
+            // The layout profile may have changed mid-session. A numeric override resolved
+            // at the last onStartInput can reference a layout that no longer exists (or now
+            // means something else); re-validate it so numeric editors do not silently keep
+            // rendering the wrong layout.
+            val droppedOverride = revalidateNumericLayoutOverride()
             val living = attachedKeyboards.mapNotNull { it.get() }
             attachedKeyboards.removeAll { it.get() == null }
             living.forEach { keyboard ->
                 keyboard.refreshStyle()
                 ime?.let { keyboard.updateSpaceLabel(it) }
+            }
+            if (droppedOverride) {
+                numericLayoutFallbackTarget?.get()?.fallbackToNumberKeyboard()
             }
         }
 
@@ -123,6 +131,7 @@ class TextKeyboard(
         private var lastLayoutCacheInvalidated = 0L
         private var forcedLayoutKey: String? = null
         private var numericLayoutKey: String? = null
+        private var numericLayoutFallbackTarget: WeakReference<KeyboardWindow>? = null
         var resolvedAuxBarConfig: AuxBarConfig? = null
         var resolvedAuxBarKeys: List<Map<String, Any?>> = emptyList()
 
@@ -234,6 +243,33 @@ class TextKeyboard(
             val option = AppPrefs.getInstance().keyboard.numericLayoutOverride.getValue()
                 .trim().takeIf { it.isNotEmpty() } ?: return null
             return option.takeIf { containsLayoutKey(json, it) }
+        }
+
+        /**
+         * Re-resolve the numeric-input layout override against the current layout profile.
+         * A layout file/profile change can invalidate the session override set at the last
+         * [onStartInput]: the referenced layout key may have been removed or renamed, or it
+         * may now map to a different layout. Returns true when a previously active override
+         * no longer resolves and has been dropped.
+         */
+        @Synchronized
+        fun revalidateNumericLayoutOverride(): Boolean {
+            val current = numericLayoutKey ?: return false
+            val resolved = resolveNumericLayoutKey()
+            if (resolved == current) return false
+            val dropped = resolved == null
+            numericLayoutKey = resolved
+            // Only update the forced slot when it still carries the numeric override; a
+            // latched/one-shot layer may have superseded it for the rest of the session.
+            if (forcedLayoutKey == current) {
+                forcedLayoutKey = resolved
+            }
+            return dropped
+        }
+
+        @Synchronized
+        fun setNumericLayoutFallbackTarget(window: KeyboardWindow?) {
+            numericLayoutFallbackTarget = window?.let(::WeakReference)
         }
 
         @Synchronized

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/TextKeyboard.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/TextKeyboard.kt
@@ -170,12 +170,28 @@ class TextKeyboard(
             // Latched layers were just cleared by the caller; the forced slot now carries
             // the numeric layout and keeps falling back to it for the rest of the session.
             forcedLayoutKey = normalized
+            var refreshedAny = false
             forEachAttachedKeyboard { keyboard ->
                 keyboard.refreshStyle()
-                keyboard.markLayoutSignatureApplied()
+                refreshedAny = true
                 ime?.let { keyboard.updateSpaceLabel(it) }
             }
+            // Mark the layout signature as applied only for keyboards that actually reloaded
+            // just now. Otherwise the next attach/onInputMethodUpdate must still see the
+            // signature mismatch and rebuild the correct forced layout.
+            if (refreshedAny) {
+                forEachAttachedKeyboard { it.markLayoutSignatureApplied() }
+            }
         }
+
+        /**
+         * Whether the current input session is a numeric editor carrying a resolvable
+         * layout override (set by [setNumericLayoutKey] from [KeyboardWindow.onStartInput]).
+         * While active, requests to show the built-in Number keyboard are redirected to the
+         * text keyboard so the override applies uniformly no matter how it is reached.
+         */
+        @Synchronized
+        fun isNumericLayoutActive(): Boolean = numericLayoutKey != null
 
         @Synchronized
         private fun forEachAttachedKeyboard(action: (TextKeyboard) -> Unit) {

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/TextKeyboard.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/TextKeyboard.kt
@@ -29,6 +29,10 @@ import kotlinx.serialization.json.*
 import kotlinx.serialization.Serializable
 import org.fcitx.fcitx5.android.ui.main.settings.behavior.utils.LayoutJsonUtils
 
+internal fun interface NumericLayoutFallbackListener {
+    fun onNumericLayoutOverrideInvalidated()
+}
+
 @SuppressLint("ViewConstructor")
 class TextKeyboard(
     context: Context,
@@ -72,22 +76,12 @@ class TextKeyboard(
 
         @Synchronized
         private fun onTextLayoutFileChanged() {
-            cachedRawLayoutJson = null
-            lastRawModified = 0L
-            lastRawLayoutFile = null
-            // The layout profile may have changed mid-session. A numeric override resolved
-            // at the last onStartInput can reference a layout that no longer exists (or now
-            // means something else); re-validate it so numeric editors do not silently keep
-            // rendering the wrong layout.
-            val droppedOverride = revalidateNumericLayoutOverride()
+            handleLayoutSourceChanged()
             val living = attachedKeyboards.mapNotNull { it.get() }
             attachedKeyboards.removeAll { it.get() == null }
             living.forEach { keyboard ->
                 keyboard.refreshStyle()
                 ime?.let { keyboard.updateSpaceLabel(it) }
-            }
-            if (droppedOverride) {
-                numericLayoutFallbackTarget?.get()?.fallbackToNumberKeyboard()
             }
         }
 
@@ -130,8 +124,8 @@ class TextKeyboard(
         private val cachedAuxBarConfigs = mutableMapOf<String, AuxBarConfig?>()
         private var lastLayoutCacheInvalidated = 0L
         private var forcedLayoutKey: String? = null
-        private var numericLayoutKey: String? = null
-        private var numericLayoutFallbackTarget: WeakReference<KeyboardWindow>? = null
+        private val numericOverride = NumericLayoutOverrideController()
+        private var numericLayoutFallbackTarget: WeakReference<NumericLayoutFallbackListener>? = null
         var resolvedAuxBarConfig: AuxBarConfig? = null
         var resolvedAuxBarKeys: List<Map<String, Any?>> = emptyList()
 
@@ -152,7 +146,8 @@ class TextKeyboard(
          */
         @Synchronized
         fun setForcedLayoutKey(layoutKey: String?) {
-            val normalized = layoutKey?.trim()?.takeIf { it.isNotEmpty() } ?: numericLayoutKey
+            numericOverride.force(layoutKey)
+            val normalized = numericOverride.forcedKey
             if (forcedLayoutKey == normalized) return
             forcedLayoutKey = normalized
             forEachAttachedKeyboard { keyboard ->
@@ -165,6 +160,20 @@ class TextKeyboard(
         @Synchronized
         fun clearForcedLayoutKey() = setForcedLayoutKey(null)
 
+        @Synchronized
+        fun activateManualNumericLayout(layoutKey: String): Boolean {
+            val wasActive = numericOverride.activateManual(layoutKey)
+            setForcedLayoutKey(layoutKey)
+            return wasActive
+        }
+
+        @Synchronized
+        fun releaseManualNumericLayout(): Boolean {
+            if (!numericOverride.releaseManual()) return false
+            setForcedLayoutKey(null)
+            return true
+        }
+
         /**
          * Set the layout used for numeric-only editors of the current input session
          * (resolved from the numeric_layout_override preference). Called from
@@ -174,8 +183,8 @@ class TextKeyboard(
         @Synchronized
         fun setNumericLayoutKey(layoutKey: String?) {
             val normalized = layoutKey?.trim()?.takeIf { it.isNotEmpty() }
-            if (numericLayoutKey == normalized && forcedLayoutKey == normalized) return
-            numericLayoutKey = normalized
+            if (numericOverride.sessionKey == normalized && forcedLayoutKey == normalized) return
+            numericOverride.beginSession(normalized)
             // Latched layers were just cleared by the caller; the forced slot now carries
             // the numeric layout and keeps falling back to it for the rest of the session.
             forcedLayoutKey = normalized
@@ -200,7 +209,7 @@ class TextKeyboard(
          * text keyboard so the override applies uniformly no matter how it is reached.
          */
         @Synchronized
-        fun isNumericLayoutActive(): Boolean = numericLayoutKey != null
+        fun isNumericLayoutActive(): Boolean = numericOverride.sessionKey != null
 
         /**
          * Release the numeric-input layout override for the rest of the current session,
@@ -212,8 +221,8 @@ class TextKeyboard(
          */
         @Synchronized
         fun dismissNumericLayoutOverride() {
-            if (numericLayoutKey == null && forcedLayoutKey == null) return
-            numericLayoutKey = null
+            if (numericOverride.sessionKey == null && forcedLayoutKey == null) return
+            numericOverride.dismiss()
             forcedLayoutKey = null
             forEachAttachedKeyboard { keyboard ->
                 keyboard.refreshStyle()
@@ -254,22 +263,29 @@ class TextKeyboard(
          */
         @Synchronized
         fun revalidateNumericLayoutOverride(): Boolean {
-            val current = numericLayoutKey ?: return false
+            val current = numericOverride.sessionKey ?: return false
             val resolved = resolveNumericLayoutKey()
             if (resolved == current) return false
-            val dropped = resolved == null
-            numericLayoutKey = resolved
-            // Only update the forced slot when it still carries the numeric override; a
-            // latched/one-shot layer may have superseded it for the rest of the session.
-            if (forcedLayoutKey == current) {
-                forcedLayoutKey = resolved
-            }
+            val dropped = numericOverride.revalidate(resolved)
+            if (forcedLayoutKey == current) forcedLayoutKey = numericOverride.forcedKey
             return dropped
         }
 
         @Synchronized
-        fun setNumericLayoutFallbackTarget(window: KeyboardWindow?) {
-            numericLayoutFallbackTarget = window?.let(::WeakReference)
+        fun handleLayoutSourceChanged(): Boolean {
+            cachedRawLayoutJson = null
+            lastRawModified = 0L
+            lastRawLayoutFile = null
+            val droppedOverride = revalidateNumericLayoutOverride()
+            if (droppedOverride) {
+                numericLayoutFallbackTarget?.get()?.onNumericLayoutOverrideInvalidated()
+            }
+            return droppedOverride
+        }
+
+        @Synchronized
+        internal fun setNumericLayoutFallbackTarget(listener: NumericLayoutFallbackListener?) {
+            numericLayoutFallbackTarget = listener?.let(::WeakReference)
         }
 
         @Synchronized

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/TextKeyboard.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/TextKeyboard.kt
@@ -122,6 +122,7 @@ class TextKeyboard(
         private val cachedAuxBarConfigs = mutableMapOf<String, AuxBarConfig?>()
         private var lastLayoutCacheInvalidated = 0L
         private var forcedLayoutKey: String? = null
+        private var numericLayoutKey: String? = null
         var resolvedAuxBarConfig: AuxBarConfig? = null
         var resolvedAuxBarKeys: List<Map<String, Any?>> = emptyList()
 
@@ -134,14 +135,18 @@ class TextKeyboard(
             lastLayoutCacheInvalidated = 0L
         }
 
+        /**
+         * Force a latched/one-shot layer, or clear it (falling back to the numeric-input
+         * layout when one is active). The numeric layout is configured per input session
+         * by [setNumericLayoutKey], so input method updates that clear layer latches keep
+         * the numeric editor on its layout.
+         */
         @Synchronized
         fun setForcedLayoutKey(layoutKey: String?) {
-            val normalized = layoutKey?.trim()?.takeIf { it.isNotEmpty() }
+            val normalized = layoutKey?.trim()?.takeIf { it.isNotEmpty() } ?: numericLayoutKey
             if (forcedLayoutKey == normalized) return
             forcedLayoutKey = normalized
-            val living = attachedKeyboards.mapNotNull { it.get() }
-            attachedKeyboards.removeAll { it.get() == null }
-            living.forEach { keyboard ->
+            forEachAttachedKeyboard { keyboard ->
                 keyboard.refreshStyle()
                 keyboard.markLayoutSignatureApplied()
                 ime?.let { keyboard.updateSpaceLabel(it) }
@@ -150,6 +155,50 @@ class TextKeyboard(
 
         @Synchronized
         fun clearForcedLayoutKey() = setForcedLayoutKey(null)
+
+        /**
+         * Set the layout used for numeric-only editors of the current input session
+         * (resolved from the numeric_layout_override preference). Called from
+         * [KeyboardWindow.onStartInput] after layer latches have been cleared, so a single
+         * update covers both transitions. `null` restores the default resolution path.
+         */
+        @Synchronized
+        fun setNumericLayoutKey(layoutKey: String?) {
+            val normalized = layoutKey?.trim()?.takeIf { it.isNotEmpty() }
+            if (numericLayoutKey == normalized && forcedLayoutKey == normalized) return
+            numericLayoutKey = normalized
+            // Latched layers were just cleared by the caller; the forced slot now carries
+            // the numeric layout and keeps falling back to it for the rest of the session.
+            forcedLayoutKey = normalized
+            forEachAttachedKeyboard { keyboard ->
+                keyboard.refreshStyle()
+                keyboard.markLayoutSignatureApplied()
+                ime?.let { keyboard.updateSpaceLabel(it) }
+            }
+        }
+
+        @Synchronized
+        private fun forEachAttachedKeyboard(action: (TextKeyboard) -> Unit) {
+            val living = attachedKeyboards.mapNotNull { it.get() }
+            attachedKeyboards.removeAll { it.get() == null }
+            living.forEach(action)
+        }
+
+        /**
+         * Resolve the layout used for numeric-only editors from the app preference
+         * "numeric_layout_override" (键盘 → 数字键盘布局). The preference names any
+         * layout key, including IME submode keys such as "rime:wanxiang"; users are
+         * responsible for the value. Returns null when unset or unresolvable, in which
+         * case the built-in number keyboard applies. Deliberately decoupled from the
+         * layout JSON: TextKeyboardLayout.json only defines text keyboard layouts.
+         */
+        @Synchronized
+        fun resolveNumericLayoutKey(): String? {
+            val json = textLayoutJson ?: return null
+            val option = AppPrefs.getInstance().keyboard.numericLayoutOverride.getValue()
+                .trim().takeIf { it.isNotEmpty() } ?: return null
+            return option.takeIf { containsLayoutKey(json, it) }
+        }
 
         @Synchronized
         fun currentLayoutHeightPercentOverride(): Int? {

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/picker/PickerWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/picker/PickerWindow.kt
@@ -75,7 +75,7 @@ class PickerWindow(
             is KeyAction.LayoutSwitchAction -> {
                 // Switch to NumberKeyboard before attaching KeyboardWindow
                 (windowManager.getEssentialWindow(KeyboardWindow) as KeyboardWindow)
-                    .switchLayout(it.act)
+                    .switchLayout(it.act, fromUserKey = true)
                 // The real switchLayout (detachCurrentLayout and attachLayout) in KeyboardWindow is postponed,
                 // so we have to postpone attachWindow as well
                 ContextCompat.getMainExecutor(context).execute {

--- a/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/KeyboardGroupFragment.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/KeyboardGroupFragment.kt
@@ -165,7 +165,12 @@ class KeyboardGroupFragment : ManagedPreferenceFragment(AppPrefs.getInstance().k
 
     private fun buildNumericLayoutOverrideSummary(): String {
         val value = AppPrefs.getInstance().keyboard.numericLayoutOverride.getValue().trim()
-        return if (value.isEmpty()) getString(R.string.numeric_layout_override_builtin) else value
+        if (value.isEmpty()) return getString(R.string.numeric_layout_override_builtin)
+        val available = value in collectLayoutLayerEntries()
+        return if (available) value else getString(
+            R.string.numeric_layout_override_unavailable,
+            value
+        )
     }
 
     /**
@@ -218,6 +223,7 @@ class KeyboardGroupFragment : ManagedPreferenceFragment(AppPrefs.getInstance().k
                 AppPrefs.getInstance().keyboard.textKeyboardLayoutProfile.setValue(sel)
                 ConfigProviders.provider = ConfigProviders.provider
                 textLayoutFileSelectPreference?.summary = buildCurrentTextLayoutFileSummary()
+                numericLayoutOverridePreference?.summary = buildNumericLayoutOverrideSummary()
                 dialog.dismiss()
             }
             .setNegativeButton(android.R.string.cancel, null)

--- a/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/KeyboardGroupFragment.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/KeyboardGroupFragment.kt
@@ -6,6 +6,7 @@ package org.fcitx.fcitx5.android.ui.main.settings.behavior
 
 import android.content.Intent
 import android.net.Uri
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.activityViewModels
 import androidx.preference.Preference
 import androidx.preference.PreferenceScreen
@@ -16,6 +17,7 @@ import org.fcitx.fcitx5.android.data.prefs.ManagedPreferenceProvider
 import org.fcitx.fcitx5.android.input.config.ConfigProviders
 import org.fcitx.fcitx5.android.input.config.UserConfigFiles
 import org.fcitx.fcitx5.android.ui.main.MainViewModel
+import org.fcitx.fcitx5.android.ui.main.settings.behavior.data.LayoutDataManager
 import org.fcitx.fcitx5.android.ui.main.settings.behavior.webeditor.ImeWebEditorBridgeServer
 
 /**
@@ -31,6 +33,7 @@ class KeyboardGroupFragment : ManagedPreferenceFragment(AppPrefs.getInstance().k
     private var calibrationPreference: Preference? = null
     private var textLayoutFileSelectPreference: Preference? = null
     private var webEditorBridgePreference: Preference? = null
+    private var numericLayoutOverridePreference: Preference? = null
 
     private val onSplitEnabledChangeListener = ManagedPreferenceProvider.OnChangeListener { key ->
         if (key == "split_keyboard_enabled") {
@@ -91,6 +94,11 @@ class KeyboardGroupFragment : ManagedPreferenceFragment(AppPrefs.getInstance().k
                 buildCurrentTextLayoutFileSummary()
             ) { showSelectTextLayoutFileDialog() }
 
+            numericLayoutOverridePreference = addTool(screen, "tool_numeric_layout_override",
+                R.string.numeric_layout_override_title,
+                buildNumericLayoutOverrideSummary()
+            ) { showNumericLayoutOverrideDialog() }
+
             webEditorBridgePreference = addTool(screen, "tool_web_editor_bridge",
                 R.string.web_editor_bridge_title, ""
             ) { toggleWebEditorBridge() }
@@ -109,6 +117,7 @@ class KeyboardGroupFragment : ManagedPreferenceFragment(AppPrefs.getInstance().k
         viewModel.setToolbarTitle(getString(groupTitleRes(group)))
         if (group == GROUP_EDITORS) {
             textLayoutFileSelectPreference?.summary = buildCurrentTextLayoutFileSummary()
+            numericLayoutOverridePreference?.summary = buildNumericLayoutOverrideSummary()
             updateWebEditorBridgeStatus()
         }
     }
@@ -153,6 +162,44 @@ class KeyboardGroupFragment : ManagedPreferenceFragment(AppPrefs.getInstance().k
     private fun displayProfile(profile: String) =
         if (profile == UserConfigFiles.DEFAULT_TEXT_KEYBOARD_LAYOUT_PROFILE)
             getString(R.string.default_) else profile
+
+    private fun buildNumericLayoutOverrideSummary(): String {
+        val value = AppPrefs.getInstance().keyboard.numericLayoutOverride.getValue().trim()
+        return if (value.isEmpty()) getString(R.string.numeric_layout_override_builtin) else value
+    }
+
+    /**
+     * 列出当前启用的布局文件中的层：基础布局与 ime:submode 子布局。
+     * 复用布局编辑器（LayoutDataManager.parseJsonText）的解析逻辑，与编辑页
+     * 下拉框枚举的层完全一致。
+     */
+    private fun collectLayoutLayerEntries(): List<String> {
+        val file = ConfigProviders.provider.textKeyboardLayoutFile() ?: return emptyList()
+        val text = runCatching { file.readText() }.getOrNull() ?: return emptyList()
+        val parsed = runCatching {
+            LayoutDataManager(requireContext()).parseJsonText(text, file.name, fallbackToDefault = false)
+        }.getOrNull() ?: return emptyList()
+        return parsed.keys.sorted()
+    }
+
+    private fun showNumericLayoutOverrideDialog() {
+        val builtin = getString(R.string.numeric_layout_override_builtin)
+        val layers = collectLayoutLayerEntries()
+        val items = listOf(builtin) + layers
+        val current = AppPrefs.getInstance().keyboard.numericLayoutOverride.getValue().trim()
+        val checked = if (current.isEmpty()) 0 else items.indexOf(current).coerceAtLeast(0)
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.numeric_layout_override_title)
+            .setSingleChoiceItems(items.toTypedArray(), checked) { dialog, which ->
+                AppPrefs.getInstance().keyboard.numericLayoutOverride
+                    .setValue(if (which == 0) "" else items[which])
+                numericLayoutOverridePreference?.summary = buildNumericLayoutOverrideSummary()
+                dialog.dismiss()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .create()
+            .show()
+    }
 
     private fun showSelectTextLayoutFileDialog() {
         val profiles = UserConfigFiles.listTextKeyboardLayoutProfiles().toMutableList()

--- a/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/KeyboardGroupFragment.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/KeyboardGroupFragment.kt
@@ -34,6 +34,12 @@ class KeyboardGroupFragment : ManagedPreferenceFragment(AppPrefs.getInstance().k
     private var textLayoutFileSelectPreference: Preference? = null
     private var webEditorBridgePreference: Preference? = null
     private var numericLayoutOverridePreference: Preference? = null
+    private data class LayoutLayerCache(
+        val path: String?,
+        val lastModified: Long,
+        val layers: List<String>
+    )
+    private var layoutLayerCache: LayoutLayerCache? = null
 
     private val onSplitEnabledChangeListener = ManagedPreferenceProvider.OnChangeListener { key ->
         if (key == "split_keyboard_enabled") {
@@ -180,11 +186,18 @@ class KeyboardGroupFragment : ManagedPreferenceFragment(AppPrefs.getInstance().k
      */
     private fun collectLayoutLayerEntries(): List<String> {
         val file = ConfigProviders.provider.textKeyboardLayoutFile() ?: return emptyList()
+        val path = file.absolutePath
+        val lastModified = file.takeIf { it.exists() }?.lastModified() ?: 0L
+        layoutLayerCache?.takeIf {
+            it.path == path && it.lastModified == lastModified
+        }?.let { return it.layers }
         val text = runCatching { file.readText() }.getOrNull() ?: return emptyList()
         val parsed = runCatching {
             LayoutDataManager(requireContext()).parseJsonText(text, file.name, fallbackToDefault = false)
         }.getOrNull() ?: return emptyList()
-        return parsed.keys.sorted()
+        return parsed.keys.sorted().also {
+            layoutLayerCache = LayoutLayerCache(path, lastModified, it)
+        }
     }
 
     private fun showNumericLayoutOverrideDialog() {

--- a/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/adapter/KeyboardLayoutAdapter.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/adapter/KeyboardLayoutAdapter.kt
@@ -751,6 +751,8 @@ class KeyboardLayoutAdapter(
             "SymbolKey" -> key["label"] as? String ?: "."
             "ReturnKey" -> context.getString(R.string.text_keyboard_layout_key_label_enter)
             "BackspaceKey" -> "⌫"
+            "NumPadKey" -> key["label"] as? String ?: "0"
+            "MiniSpaceKey" -> context.getString(R.string.text_keyboard_layout_key_label_minispace)
             "MacroKey" -> {
                 // 显示 label 值，如果有 labelText 且当前在 submode 中，优先显示 labelText
                 val label = key["label"] as? String ?: "M"

--- a/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/dialog/KeyEditorActivity.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/dialog/KeyEditorActivity.kt
@@ -130,7 +130,11 @@ class KeyEditorActivity : AppCompatActivity() {
     private val alphabetDisplayTextRowBindings = mutableListOf<KeyboardEditorUiBuilder.DisplayTextRowBinding>()
 
     private var layoutSwitchLabelEdit: EditText? = null
+    private var layoutSwitchTargetSpinner: Spinner? = null
     private var layoutSwitchWeightEdit: EditText? = null
+
+    private var numPadLabelEdit: EditText? = null
+    private var numPadSymSpinner: Spinner? = null
 
     private var symbolLabelEdit: EditText? = null
     private var symbolWeightEdit: EditText? = null
@@ -384,7 +388,10 @@ class KeyEditorActivity : AppCompatActivity() {
         alphabetDisplayTextSimpleEdit = null
         alphabetDisplayTextRowBindings.clear()
         layoutSwitchLabelEdit = null
+        layoutSwitchTargetSpinner = null
         layoutSwitchWeightEdit = null
+        numPadLabelEdit = null
+        numPadSymSpinner = null
         symbolLabelEdit = null
         symbolWeightEdit = null
         macroLabelEdit = null
@@ -489,6 +496,22 @@ class KeyEditorActivity : AppCompatActivity() {
                 )
                 layoutSwitchLabelEdit = labelEdit.second
                 fieldsContainer.addView(labelEdit.first)
+                layoutSwitchTargetSpinner = uiBuilder.createSwitchTargetSpinner(
+                    fieldsContainer,
+                    keyData["subLabel"] as? String ?: ""
+                )
+                layoutSwitchTargetSpinner?.onItemSelectedListener =
+                    object : android.widget.AdapterView.OnItemSelectedListener {
+                        override fun onItemSelected(
+                            parent: android.widget.AdapterView<*>?,
+                            view: android.view.View?,
+                            position: Int,
+                            id: Long
+                        ) {
+                            updateActionButtonState()
+                        }
+                        override fun onNothingSelected(parent: android.widget.AdapterView<*>?) {}
+                    }
                 if (!disableWeightEditing) {
                     val weightEdit = uiBuilder.createEditField(
                         getString(R.string.text_keyboard_layout_key_weight),
@@ -728,6 +751,62 @@ class KeyEditorActivity : AppCompatActivity() {
             }
 
             "CommaKey", "LanguageKey", "SpaceKey" -> {
+                if (!disableWeightEditing) {
+                    val weightEdit = uiBuilder.createEditField(
+                        getString(R.string.text_keyboard_layout_key_weight),
+                        (keyData["weight"] as? Number)?.toString() ?: ""
+                    )
+                    simpleWeightEdit = weightEdit.second
+                    fieldsContainer.addView(weightEdit.first)
+                }
+            }
+
+            "NumPadKey" -> {
+                val labelEdit = uiBuilder.createEditField(
+                    getString(R.string.text_keyboard_layout_key_label),
+                    keyData["label"] as? String ?: "0"
+                )
+                numPadLabelEdit = labelEdit.second
+                fieldsContainer.addView(labelEdit.first)
+                val currentSym = when (val s = keyData["sym"]) {
+                    is Number -> s.toInt()
+                    is String -> LayoutJsonUtils.resolveKeysym(s) ?: 0
+                    else -> 0
+                }
+                numPadSymSpinner = uiBuilder.createNumPadSymSpinner(fieldsContainer, currentSym)
+                // Keep the displayed label in sync with the selected numpad symbol, unless the
+                // user typed a custom label. Otherwise the preview would keep showing the old
+                // label after switching the symbol.
+                numPadSymSpinner?.onItemSelectedListener =
+                    object : android.widget.AdapterView.OnItemSelectedListener {
+                        override fun onItemSelected(
+                            parent: android.widget.AdapterView<*>?,
+                            view: android.view.View?,
+                            position: Int,
+                            id: Long
+                        ) {
+                            val option = KeyboardEditorUiBuilder.NUMPAD_OPTIONS.getOrNull(position) ?: return
+                            val current = numPadLabelEdit?.text?.toString().orEmpty()
+                            val synced = current.isEmpty() ||
+                                KeyboardEditorUiBuilder.NUMPAD_OPTIONS.any { it.label == current }
+                            if (synced) numPadLabelEdit?.setText(option.label)
+                            updateActionButtonState()
+                        }
+                        override fun onNothingSelected(parent: android.widget.AdapterView<*>?) {
+                            updateActionButtonState()
+                        }
+                    }
+                if (!disableWeightEditing) {
+                    val weightEdit = uiBuilder.createEditField(
+                        getString(R.string.text_keyboard_layout_key_weight),
+                        (keyData["weight"] as? Number)?.toString() ?: ""
+                    )
+                    simpleWeightEdit = weightEdit.second
+                    fieldsContainer.addView(weightEdit.first)
+                }
+            }
+
+            "MiniSpaceKey" -> {
                 if (!disableWeightEditing) {
                     val weightEdit = uiBuilder.createEditField(
                         getString(R.string.text_keyboard_layout_key_weight),
@@ -1238,9 +1317,10 @@ class KeyEditorActivity : AppCompatActivity() {
             "LayoutSwitchKey" -> {
                 val label = layoutSwitchLabelEdit?.text?.toString()?.ifEmpty { "?123" }.orEmpty()
                 if (label.isNotEmpty()) draft["label"] = label
-                (keyData["subLabel"] as? String)
-                    ?.takeIf { it.isNotEmpty() }
-                    ?.let { draft["subLabel"] = it }
+                val target = layoutSwitchTargetSpinner?.selectedItemPosition
+                    ?.let { KeyboardEditorUiBuilder.SWITCH_TARGET_OPTIONS.getOrNull(it)?.value }
+                    ?.orEmpty()
+                if (!target.isNullOrEmpty()) draft["subLabel"] = target
                 val swipeLabel = nonMacroSwipeLabelEdit?.text?.toString()?.trim().orEmpty()
                 if (swipeLabel.isNotEmpty()) draft["swipeLabel"] = swipeLabel
                 if (!disableWeightEditing) {
@@ -1320,6 +1400,23 @@ class KeyEditorActivity : AppCompatActivity() {
             }
 
             "CommaKey", "LanguageKey", "SpaceKey" -> {
+                if (!disableWeightEditing) {
+                    parseWeight(simpleWeightEdit?.text?.toString())?.let { draft["weight"] = it }
+                }
+            }
+
+            "NumPadKey" -> {
+                val label = numPadLabelEdit?.text?.toString()?.ifEmpty { "0" }.orEmpty()
+                if (label.isNotEmpty()) draft["label"] = label
+                numPadSymSpinner?.selectedItemPosition
+                    ?.let { KeyboardEditorUiBuilder.NUMPAD_OPTIONS.getOrNull(it)?.sym }
+                    ?.let { draft["sym"] = it }
+                if (!disableWeightEditing) {
+                    parseWeight(simpleWeightEdit?.text?.toString())?.let { draft["weight"] = it }
+                }
+            }
+
+            "MiniSpaceKey" -> {
                 if (!disableWeightEditing) {
                     parseWeight(simpleWeightEdit?.text?.toString())?.let { draft["weight"] = it }
                 }
@@ -1497,6 +1594,7 @@ class KeyEditorActivity : AppCompatActivity() {
             alphabetDisplayTextModeItems,
             alphabetDisplayTextRowBindings,
             layoutSwitchLabelEdit,
+            layoutSwitchTargetSpinner,
             layoutSwitchWeightEdit,
             symbolLabelEdit,
             symbolWeightEdit,
@@ -1589,6 +1687,7 @@ class KeyEditorActivity : AppCompatActivity() {
         alphabetDisplayTextModeItems: List<KeyboardEditorUiBuilder.DisplayTextItem>,
         alphabetDisplayTextRowBindings: List<KeyboardEditorUiBuilder.DisplayTextRowBinding>,
         layoutSwitchLabelEdit: EditText?,
+        layoutSwitchTargetSpinner: Spinner?,
         layoutSwitchWeightEdit: EditText?,
         symbolLabelEdit: EditText?,
         symbolWeightEdit: EditText?,
@@ -1679,9 +1778,10 @@ class KeyEditorActivity : AppCompatActivity() {
 
             "LayoutSwitchKey" -> {
                 newKey["label"] = layoutSwitchLabelEdit?.text?.toString()?.ifEmpty { "?123" }.orEmpty()
-                (keyData["subLabel"] as? String)
-                    ?.takeIf { it.isNotEmpty() }
-                    ?.let { newKey["subLabel"] = it }
+                val target = layoutSwitchTargetSpinner?.selectedItemPosition
+                    ?.let { KeyboardEditorUiBuilder.SWITCH_TARGET_OPTIONS.getOrNull(it)?.value }
+                    ?.orEmpty()
+                if (!target.isNullOrEmpty()) newKey["subLabel"] = target
                 val swipeLabel = nonMacroSwipeLabelEdit?.text?.toString()?.trim().orEmpty()
                 if (swipeLabel.isNotEmpty()) newKey["swipeLabel"] = swipeLabel
                 if (!disableWeightEditing) {
@@ -1766,6 +1866,22 @@ class KeyEditorActivity : AppCompatActivity() {
             }
 
             "CommaKey", "LanguageKey", "SpaceKey" -> {
+                if (!disableWeightEditing) {
+                    parseWeight(simpleWeightEdit?.text?.toString())?.let { newKey["weight"] = it }
+                }
+            }
+
+            "NumPadKey" -> {
+                newKey["label"] = numPadLabelEdit?.text?.toString()?.ifEmpty { "0" }.orEmpty()
+                numPadSymSpinner?.selectedItemPosition
+                    ?.let { KeyboardEditorUiBuilder.NUMPAD_OPTIONS.getOrNull(it)?.sym }
+                    ?.let { newKey["sym"] = it }
+                if (!disableWeightEditing) {
+                    parseWeight(simpleWeightEdit?.text?.toString())?.let { newKey["weight"] = it }
+                }
+            }
+
+            "MiniSpaceKey" -> {
                 if (!disableWeightEditing) {
                     parseWeight(simpleWeightEdit?.text?.toString())?.let { newKey["weight"] = it }
                 }

--- a/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/dialog/KeyboardEditorUiBuilder.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/dialog/KeyboardEditorUiBuilder.kt
@@ -18,6 +18,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import org.fcitx.fcitx5.android.R
+import org.fcitx.fcitx5.android.core.FcitxKeyMapping
 import splitties.dimensions.dp
 import splitties.resources.styledColor
 
@@ -26,6 +27,19 @@ import splitties.resources.styledColor
  * for the keyboard edit dialog.
  */
 class KeyboardEditorUiBuilder(private val activity: AppCompatActivity) {
+
+    /**
+     * A selectable switch target for [org.fcitx.fcitx5.android.input.keyboard.LayoutSwitchKey].
+     * The value is stored as the key's `subLabel`; an empty value selects the default
+     * behavior (last symbol layout, "?123").
+     */
+    data class SwitchTargetOption(val value: String, val labelRes: Int)
+
+    /**
+     * A selectable numpad symbol for [org.fcitx.fcitx5.android.input.keyboard.NumPadKey].
+     * [sym] is the Fcitx keysym sent with NumLock state on press.
+     */
+    data class NumPadOption(val label: String, val sym: Int)
 
     companion object {
         private const val DIALOG_LABEL_TEXT_SIZE_SP = 13f
@@ -41,7 +55,36 @@ class KeyboardEditorUiBuilder(private val activity: AppCompatActivity) {
             "SymbolKey",
             "ReturnKey",
             "BackspaceKey",
+            "NumPadKey",
+            "MiniSpaceKey",
             "MacroKey"
+        )
+
+        val SWITCH_TARGET_OPTIONS = listOf(
+            SwitchTargetOption("", R.string.text_keyboard_layout_switch_target_default),
+            SwitchTargetOption("Text", R.string.text_keyboard_layout_switch_target_text),
+            SwitchTargetOption("Number", R.string.text_keyboard_layout_switch_target_number),
+            SwitchTargetOption("Symbol", R.string.text_keyboard_layout_switch_target_symbol)
+        )
+
+        val NUMPAD_OPTIONS = listOf(
+            NumPadOption("0", FcitxKeyMapping.FcitxKey_KP_0),
+            NumPadOption("1", FcitxKeyMapping.FcitxKey_KP_1),
+            NumPadOption("2", FcitxKeyMapping.FcitxKey_KP_2),
+            NumPadOption("3", FcitxKeyMapping.FcitxKey_KP_3),
+            NumPadOption("4", FcitxKeyMapping.FcitxKey_KP_4),
+            NumPadOption("5", FcitxKeyMapping.FcitxKey_KP_5),
+            NumPadOption("6", FcitxKeyMapping.FcitxKey_KP_6),
+            NumPadOption("7", FcitxKeyMapping.FcitxKey_KP_7),
+            NumPadOption("8", FcitxKeyMapping.FcitxKey_KP_8),
+            NumPadOption("9", FcitxKeyMapping.FcitxKey_KP_9),
+            NumPadOption("+", FcitxKeyMapping.FcitxKey_KP_Add),
+            NumPadOption("-", FcitxKeyMapping.FcitxKey_KP_Subtract),
+            NumPadOption("*", FcitxKeyMapping.FcitxKey_KP_Multiply),
+            NumPadOption("/", FcitxKeyMapping.FcitxKey_KP_Divide),
+            NumPadOption(",", FcitxKeyMapping.FcitxKey_KP_Separator),
+            NumPadOption(".", FcitxKeyMapping.FcitxKey_KP_Decimal),
+            NumPadOption("=", FcitxKeyMapping.FcitxKey_KP_Equal)
         )
     }
 
@@ -123,6 +166,98 @@ class KeyboardEditorUiBuilder(private val activity: AppCompatActivity) {
         container.addView(labelView)
         container.addView(editText)
         return container to editText
+    }
+
+    /**
+     * Create a dropdown selector for a [LayoutSwitchKey]'s switch target (stored as the
+     * key's `subLabel`). Preselects the entry matching [currentValue]; empty matches the
+     * default option.
+     */
+    fun createSwitchTargetSpinner(
+        container: LinearLayout,
+        currentValue: String
+    ): Spinner {
+        val labelView = TextView(activity).apply {
+            text = activity.getString(R.string.text_keyboard_layout_switch_target)
+            textSize = DIALOG_LABEL_TEXT_SIZE_SP
+            setTextColor(activity.styledColor(android.R.attr.textColorSecondary))
+            layoutParams = LinearLayout.LayoutParams(activity.dp(96), LinearLayout.LayoutParams.WRAP_CONTENT).apply {
+                rightMargin = activity.dp(8)
+            }
+        }
+        val spinner = Spinner(activity).apply {
+            layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT).apply {
+                weight = 1f
+            }
+        }
+        val adapter = object : ArrayAdapter<SwitchTargetOption>(
+            activity, android.R.layout.simple_spinner_item, SWITCH_TARGET_OPTIONS
+        ) {
+            override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+                val view = super.getView(position, convertView, parent)
+                getItem(position)?.let { option ->
+                    (view as? TextView)?.text = activity.getString(option.labelRes)
+                }
+                return view
+            }
+            override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
+                val view = super.getDropDownView(position, convertView, parent)
+                getItem(position)?.let { option ->
+                    (view as? TextView)?.text = activity.getString(option.labelRes)
+                }
+                return view
+            }
+        }
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        spinner.adapter = adapter
+        val position = SWITCH_TARGET_OPTIONS.indexOfFirst { it.value == currentValue }
+        if (position >= 0) spinner.setSelection(position)
+        val row = LinearLayout(activity).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(0, activity.dp(4), 0, activity.dp(4))
+            addView(labelView)
+            addView(spinner)
+        }
+        container.addView(row)
+        return spinner
+    }
+
+    /**
+     * Create a dropdown selector for a [NumPadKey]'s symbol. Preselects the entry whose
+     * keysym matches [currentSym]; an unknown keysym falls back to the first option.
+     */
+    fun createNumPadSymSpinner(
+        container: LinearLayout,
+        currentSym: Int
+    ): Spinner {
+        val labelView = TextView(activity).apply {
+            text = activity.getString(R.string.text_keyboard_layout_numpad_symbol)
+            textSize = DIALOG_LABEL_TEXT_SIZE_SP
+            setTextColor(activity.styledColor(android.R.attr.textColorSecondary))
+            layoutParams = LinearLayout.LayoutParams(activity.dp(96), LinearLayout.LayoutParams.WRAP_CONTENT).apply {
+                rightMargin = activity.dp(8)
+            }
+        }
+        val spinner = Spinner(activity).apply {
+            layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT).apply {
+                weight = 1f
+            }
+        }
+        val adapter = ArrayAdapter(activity, android.R.layout.simple_spinner_item, NUMPAD_OPTIONS.map { it.label })
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        spinner.adapter = adapter
+        val position = NUMPAD_OPTIONS.indexOfFirst { it.sym == currentSym }
+        if (position >= 0) spinner.setSelection(position)
+        val row = LinearLayout(activity).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(0, activity.dp(4), 0, activity.dp(4))
+            addView(labelView)
+            addView(spinner)
+        }
+        container.addView(row)
+        return spinner
     }
 
     /**

--- a/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/utils/LayoutJsonUtils.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/utils/LayoutJsonUtils.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import kotlinx.serialization.json.*
 import org.fcitx.fcitx5.android.input.keyboard.*
 import org.fcitx.fcitx5.android.input.keyboard.AuxBarConfig
+import org.fcitx.fcitx5.android.core.FcitxKeyMapping
 
 // Import Macro types explicitly
 import org.fcitx.fcitx5.android.input.keyboard.MacroAction
@@ -34,6 +35,8 @@ object LayoutJsonUtils {
         "label",
         "altLabel",
         "subLabel",
+        "swipeLabel",
+        "sym",
         "weight",
         "rowHeightPercent",
         "tap",
@@ -243,6 +246,7 @@ object LayoutJsonUtils {
             longPressLabel = obj["longPressLabel"]?.jsonPrimitive?.content,
             subLabel = obj["subLabel"]?.jsonPrimitive?.content,
             swipeLabel = obj["swipeLabel"]?.jsonPrimitive?.content,
+            sym = obj["sym"]?.jsonPrimitive?.content?.let { resolveKeysym(it) },
             weight = parseOptionalFloat(obj["weight"]),
             rowHeightPercent = parseOptionalFloat(obj["rowHeightPercent"]),
             textColor = parseOptionalInt(obj["textColor"]),
@@ -404,6 +408,7 @@ object LayoutJsonUtils {
     private fun normalizeKeyValue(key: String, value: Any?): Any? {
         if (key != "weight" &&
             key != "rowHeightPercent" &&
+            key != "sym" &&
             key != "textColor" &&
             key != "altTextColor" &&
             key != "backgroundColor" &&
@@ -418,6 +423,8 @@ object LayoutJsonUtils {
                     ?.let {
                         if (key == "weight" || key == "rowHeightPercent") {
                             it.toFloatOrNull()
+                        } else if (key == "sym") {
+                            resolveKeysym(it)
                         } else {
                             when {
                                 it.startsWith("#") -> it.removePrefix("#").toLongOrNull(16)?.toInt()
@@ -429,6 +436,108 @@ object LayoutJsonUtils {
             }
             else -> null
         }
+    }
+
+    /**
+     * 将按键名解析为 Fcitx keysym（大小写不敏感），兼容以下格式：
+     * - 十进制数字（如 "65458"）
+     * - 十六进制（"0xffb2" 或 "#ffb2"）
+     * - X11/Fcitx 按键名（如 "KP_2"、"KP_Add"、"plus"、"BackSpace"）
+     *
+     * 纯数字与运算符标签按数字键盘语义解析到 KP_* keysym。
+     */
+    fun resolveKeysym(input: String?): Int? {
+        if (input.isNullOrBlank()) return null
+        val trimmed = input.trim()
+        // 先查按键名表：纯数字标签（如 "2"）按数字键盘语义解析为 KP_*，
+        // 避免 "2" 被误当成十进制 keysym 2（0x02，控制符）。
+        SYM_NAME_TO_CODE[trimmed]?.let { return it }
+        SYM_NAME_TO_CODE[trimmed.lowercase()]?.let { return it }
+        trimmed.toIntOrNull()?.let { return it }
+        if (trimmed.startsWith("0x", ignoreCase = true)) {
+            trimmed.removePrefix("0x").toIntOrNull(16)?.let { return it }
+        }
+        if (trimmed.startsWith("#")) {
+            trimmed.removePrefix("#").toIntOrNull(16)?.let { return it }
+        }
+        return null
+    }
+
+    /**
+     * 将 Fcitx keysym 转换为人类可读的规范按键名（如 65458 → "KP_2"）。
+     * 未知的 keysym 原样返回整数，保证 round-trip 兼容。
+     */
+    fun keysymToName(sym: Int): Any? = SYM_CODE_TO_NAME[sym] ?: sym
+
+    private val SYM_CODE_TO_NAME: Map<Int, String> = buildMap {
+        for (i in 0..9) {
+            put(FcitxKeyMapping.FcitxKey_KP_0 + i, "KP_$i")
+        }
+        put(FcitxKeyMapping.FcitxKey_KP_Add, "KP_Add")
+        put(FcitxKeyMapping.FcitxKey_KP_Subtract, "KP_Subtract")
+        put(FcitxKeyMapping.FcitxKey_KP_Multiply, "KP_Multiply")
+        put(FcitxKeyMapping.FcitxKey_KP_Divide, "KP_Divide")
+        put(FcitxKeyMapping.FcitxKey_KP_Decimal, "KP_Decimal")
+        put(FcitxKeyMapping.FcitxKey_KP_Separator, "KP_Separator")
+        put(FcitxKeyMapping.FcitxKey_KP_Equal, "KP_Equal")
+        put(FcitxKeyMapping.FcitxKey_KP_Enter, "KP_Enter")
+    }
+
+    private val SYM_NAME_TO_CODE: Map<String, Int> = buildMap {
+        for (i in 0..9) {
+            put(i.toString(), FcitxKeyMapping.FcitxKey_KP_0 + i)
+            put("kp_$i", FcitxKeyMapping.FcitxKey_KP_0 + i)
+        }
+        for (c in 'a'..'z') {
+            put(c.toString(), FcitxKeyMapping.FcitxKey_a + (c - 'a'))
+            put(c.uppercaseChar().toString(), FcitxKeyMapping.FcitxKey_a + (c - 'a'))
+        }
+        put("+", FcitxKeyMapping.FcitxKey_KP_Add)
+        put("-", FcitxKeyMapping.FcitxKey_KP_Subtract)
+        put("*", FcitxKeyMapping.FcitxKey_KP_Multiply)
+        put("/", FcitxKeyMapping.FcitxKey_KP_Divide)
+        put(",", FcitxKeyMapping.FcitxKey_KP_Separator)
+        put(".", FcitxKeyMapping.FcitxKey_KP_Decimal)
+        put("=", FcitxKeyMapping.FcitxKey_KP_Equal)
+        put("kp_add", FcitxKeyMapping.FcitxKey_KP_Add)
+        put("kp_subtract", FcitxKeyMapping.FcitxKey_KP_Subtract)
+        put("kp_multiply", FcitxKeyMapping.FcitxKey_KP_Multiply)
+        put("kp_divide", FcitxKeyMapping.FcitxKey_KP_Divide)
+        put("kp_decimal", FcitxKeyMapping.FcitxKey_KP_Decimal)
+        put("kp_separator", FcitxKeyMapping.FcitxKey_KP_Separator)
+        put("kp_equal", FcitxKeyMapping.FcitxKey_KP_Equal)
+        put("kp_enter", FcitxKeyMapping.FcitxKey_KP_Enter)
+        // 常用 X11/Fcitx 规范键名（小写）
+        put("space", FcitxKeyMapping.FcitxKey_space)
+        put("numbersign", FcitxKeyMapping.FcitxKey_numbersign)
+        put("apostrophe", FcitxKeyMapping.FcitxKey_apostrophe)
+        put("asterisk", FcitxKeyMapping.FcitxKey_asterisk)
+        put("plus", FcitxKeyMapping.FcitxKey_plus)
+        put("comma", FcitxKeyMapping.FcitxKey_comma)
+        put("minus", FcitxKeyMapping.FcitxKey_minus)
+        put("period", FcitxKeyMapping.FcitxKey_period)
+        put("slash", FcitxKeyMapping.FcitxKey_slash)
+        put("semicolon", FcitxKeyMapping.FcitxKey_semicolon)
+        put("equal", FcitxKeyMapping.FcitxKey_equal)
+        put("at", FcitxKeyMapping.FcitxKey_at)
+        put("bracketleft", FcitxKeyMapping.FcitxKey_bracketleft)
+        put("bracketright", FcitxKeyMapping.FcitxKey_bracketright)
+        put("backslash", FcitxKeyMapping.FcitxKey_backslash)
+        put("grave", FcitxKeyMapping.FcitxKey_grave)
+        put("return", FcitxKeyMapping.FcitxKey_Return)
+        put("backspace", FcitxKeyMapping.FcitxKey_BackSpace)
+        put("tab", FcitxKeyMapping.FcitxKey_Tab)
+        put("escape", FcitxKeyMapping.FcitxKey_Escape)
+        put("up", FcitxKeyMapping.FcitxKey_Up)
+        put("down", FcitxKeyMapping.FcitxKey_Down)
+        put("left", FcitxKeyMapping.FcitxKey_Left)
+        put("right", FcitxKeyMapping.FcitxKey_Right)
+        put("home", FcitxKeyMapping.FcitxKey_Home)
+        put("end", FcitxKeyMapping.FcitxKey_End)
+        put("page_up", FcitxKeyMapping.FcitxKey_Page_Up)
+        put("page_down", FcitxKeyMapping.FcitxKey_Page_Down)
+        put("insert", FcitxKeyMapping.FcitxKey_Insert)
+        put("delete", FcitxKeyMapping.FcitxKey_Delete)
     }
 
     /**
@@ -483,6 +592,7 @@ object LayoutJsonUtils {
         val longPressLabel: String? = null,  // MacroKey 使用
         val subLabel: String? = null,  // LayoutSwitchKey 使用
         val swipeLabel: String? = null,  // 非 Macro 的 swipe 提示
+        val sym: Int? = null,  // NumPadKey 使用（Fcitx keysym）
         val weight: Float? = null,
         val textColor: Int? = null,
         val textColorMonet: String? = null,
@@ -518,6 +628,8 @@ object LayoutJsonUtils {
             is ReturnKey -> "ReturnKey"
             is BackspaceKey -> "BackspaceKey"
             is MacroKey -> "MacroKey"
+            is NumPadKey -> "NumPadKey"
+            is MiniSpaceKey -> "MiniSpaceKey"
             else -> "SpaceKey"
         }
 
@@ -575,6 +687,14 @@ object LayoutJsonUtils {
                 json["weight"] = appearance.percentWidth
                 keyDef.swipeLabel?.let { json["swipeLabel"] = it }
                 keyDef.swipe?.let { json["swipe"] = macroActionToJson(it) }
+            }
+            is NumPadKey -> {
+                json["label"] = (appearance as? KeyDef.Appearance.Text)?.displayText
+                json["sym"] = keysymToName(keyDef.sym)
+                json["weight"] = appearance.percentWidth.takeIf { it != 0.1f }
+            }
+            is MiniSpaceKey -> {
+                json["weight"] = appearance.percentWidth.takeIf { it != 0.15f }
             }
             is MacroKey -> {
                 json["label"] = keyDef.label
@@ -800,6 +920,14 @@ object LayoutJsonUtils {
                 backgroundColorMonet = key.backgroundColorMonet,
                 shadowColor = key.shadowColor,
                 shadowColorMonet = key.shadowColorMonet
+            )
+            "NumPadKey" -> NumPadKey(
+                displayText = key.label ?: "0",
+                sym = key.sym ?: resolveKeysym(key.label) ?: FcitxKeyMapping.FcitxKey_KP_0,
+                percentWidth = key.weight ?: 0.1f
+            )
+            "MiniSpaceKey" -> MiniSpaceKey(
+                percentWidth = key.weight ?: 0.15f
             )
             "MacroKey" -> {
                 val tap = key.tap ?: throw IllegalArgumentException("MacroKey requires 'tap' action")
@@ -1093,7 +1221,14 @@ object LayoutJsonUtils {
         val ordered = LinkedHashMap<String, Any?>()
         KEY_FIELD_ORDER.forEach { key ->
             if (keyMap.containsKey(key)) {
-                ordered[key] = keyMap[key]
+                ordered[key] = if (key == "sym" && keyMap["type"] == "NumPadKey") {
+                    when (val sym = keyMap[key]) {
+                        is Number -> keysymToName(sym.toInt())
+                        else -> sym
+                    }
+                } else {
+                    keyMap[key]
+                }
             }
         }
         keyMap.forEach { (key, value) ->

--- a/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/utils/LayoutJsonUtils.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/ui/main/settings/behavior/utils/LayoutJsonUtils.kt
@@ -924,10 +924,22 @@ object LayoutJsonUtils {
             "NumPadKey" -> NumPadKey(
                 displayText = key.label ?: "0",
                 sym = key.sym ?: resolveKeysym(key.label) ?: FcitxKeyMapping.FcitxKey_KP_0,
-                percentWidth = key.weight ?: 0.1f
+                percentWidth = key.weight ?: 0.1f,
+                textColor = key.textColor,
+                textColorMonet = key.textColorMonet,
+                backgroundColor = key.backgroundColor,
+                backgroundColorMonet = key.backgroundColorMonet,
+                shadowColor = key.shadowColor,
+                shadowColorMonet = key.shadowColorMonet
             )
             "MiniSpaceKey" -> MiniSpaceKey(
-                percentWidth = key.weight ?: 0.15f
+                percentWidth = key.weight ?: 0.15f,
+                textColor = key.textColor,
+                textColorMonet = key.textColorMonet,
+                backgroundColor = key.backgroundColor,
+                backgroundColorMonet = key.backgroundColorMonet,
+                shadowColor = key.shadowColor,
+                shadowColorMonet = key.shadowColorMonet
             )
             "MacroKey" -> {
                 val tap = key.tap ?: throw IllegalArgumentException("MacroKey requires 'tap' action")

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -261,6 +261,7 @@
     <string name="text_keyboard_layout_layout_name_hint">z. B.: rime, pinyin</string>
     <string name="numeric_layout_override_title">Tastaturlayout für Zahlenfelder</string>
     <string name="numeric_layout_override_builtin">Integrierter Ziffernblock</string>
+    <string name="numeric_layout_override_unavailable">%1$s (im aktuellen Profil nicht verfügbar)</string>
     <string name="text_keyboard_layout_copy_from">Aus bestehendem Layout kopieren</string>
     <string name="text_keyboard_layout_name_empty">Layoutname darf nicht leer sein</string>
     <string name="text_keyboard_layout_delete_key_confirm">Diese Taste löschen?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -259,6 +259,8 @@
     <string name="text_keyboard_layout_key_color_monet_unavailable">Monet-Dynamikfarbe nicht verfügbar</string>
     <string name="text_keyboard_layout_layout_name">Layoutname</string>
     <string name="text_keyboard_layout_layout_name_hint">z. B.: rime, pinyin</string>
+    <string name="numeric_layout_override_title">Tastaturlayout für Zahlenfelder</string>
+    <string name="numeric_layout_override_builtin">Integrierter Ziffernblock</string>
     <string name="text_keyboard_layout_copy_from">Aus bestehendem Layout kopieren</string>
     <string name="text_keyboard_layout_name_empty">Layoutname darf nicht leer sein</string>
     <string name="text_keyboard_layout_delete_key_confirm">Diese Taste löschen?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -282,10 +282,17 @@
     <string name="text_keyboard_layout_macro_event_preview">%1$s → … (insgesamt %2$d Schritte)</string>
     <string name="text_keyboard_layout_alt_label">Alternatives Etikett</string>
     <string name="text_keyboard_layout_swipe_label">Wisch-Label</string>
+    <string name="text_keyboard_layout_switch_target">Ziel</string>
+    <string name="text_keyboard_layout_switch_target_default">Standard (?123 / letztes Symbol-Layout)</string>
+    <string name="text_keyboard_layout_switch_target_text">Texttastatur</string>
+    <string name="text_keyboard_layout_switch_target_number">Zifferntastatur</string>
+    <string name="text_keyboard_layout_switch_target_symbol">Symbolauswahl</string>
+    <string name="text_keyboard_layout_numpad_symbol">Ziffernblock-Symbol</string>
     <string name="text_keyboard_layout_display_value_hint">Anzeigewert</string>
     <string name="text_keyboard_layout_key_label_caps">Caps</string>
     <string name="text_keyboard_layout_key_label_lang">Lang</string>
     <string name="text_keyboard_layout_key_label_space">Space</string>
+    <string name="text_keyboard_layout_key_label_minispace">␣</string>
     <string name="text_keyboard_layout_key_label_enter">Enter</string>
     <string name="text_keyboard_layout_alphabet_key_main_required">Hauptzeichen darf nicht leer sein</string>
     <string name="text_keyboard_layout_alphabet_key_alt_required">Alternatives Zeichen darf nicht leer sein</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -210,6 +210,8 @@
     <string name="text_keyboard_layout_key_color_monet_unavailable">Color dinámico de Monet no disponible</string>
     <string name="text_keyboard_layout_layout_name">Nombre de la distribución</string>
     <string name="text_keyboard_layout_layout_name_hint">p. ej., rime, pinyin</string>
+    <string name="numeric_layout_override_title">Diseño de teclado numérico</string>
+    <string name="numeric_layout_override_builtin">Teclado numérico integrado</string>
     <string name="text_keyboard_layout_copy_from">Copiar de una distribución existente</string>
     <string name="text_keyboard_layout_name_empty">El nombre de la distribución no puede estar vacío</string>
     <string name="text_keyboard_layout_delete_key_confirm">¿Eliminar esta tecla?</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -212,6 +212,7 @@
     <string name="text_keyboard_layout_layout_name_hint">p. ej., rime, pinyin</string>
     <string name="numeric_layout_override_title">Diseño de teclado numérico</string>
     <string name="numeric_layout_override_builtin">Teclado numérico integrado</string>
+    <string name="numeric_layout_override_unavailable">%1$s (no disponible en el perfil actual)</string>
     <string name="text_keyboard_layout_copy_from">Copiar de una distribución existente</string>
     <string name="text_keyboard_layout_name_empty">El nombre de la distribución no puede estar vacío</string>
     <string name="text_keyboard_layout_delete_key_confirm">¿Eliminar esta tecla?</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -227,6 +227,7 @@
     <string name="text_keyboard_layout_key_label_caps">Caps</string>
     <string name="text_keyboard_layout_key_label_lang">Lang</string>
     <string name="text_keyboard_layout_key_label_space">Space</string>
+    <string name="text_keyboard_layout_key_label_minispace">␣</string>
     <string name="text_keyboard_layout_key_label_enter">Enter</string>
     <string name="space_key_label_mode">Estilo de etiqueta de la barra espaciadora</string>
     <string name="space_key_label_mode_default">Predeterminado</string>
@@ -348,6 +349,12 @@
     <string name="text_keyboard_layout_macro_event_preview">%1$s → … (%2$d pasos en total)</string>
     <string name="text_keyboard_layout_alt_label">Etiqueta alternativa</string>
     <string name="text_keyboard_layout_swipe_label">Etiqueta de deslizamiento</string>
+    <string name="text_keyboard_layout_switch_target">Destino</string>
+    <string name="text_keyboard_layout_switch_target_default">Predeterminado (?123 / último diseño de símbolos)</string>
+    <string name="text_keyboard_layout_switch_target_text">Teclado de texto</string>
+    <string name="text_keyboard_layout_switch_target_number">Teclado numérico</string>
+    <string name="text_keyboard_layout_switch_target_symbol">Selector de símbolos</string>
+    <string name="text_keyboard_layout_numpad_symbol">Símbolo del teclado numérico</string>
 
     <!-- Macro Editor -->
     <string name="macro_editor_title">Editar %1$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -358,6 +358,7 @@
     <string name="text_keyboard_layout_layout_name_hint">例：rime、pinyin</string>
     <string name="numeric_layout_override_title">数字入力のキーボードレイアウト</string>
     <string name="numeric_layout_override_builtin">内蔵の数字キーボード</string>
+    <string name="numeric_layout_override_unavailable">%1$s（現在のプロファイルでは利用できません）</string>
     <string name="text_keyboard_layout_copy_from">既存レイアウトからコピー</string>
     <string name="text_keyboard_layout_name_empty">レイアウト名は空にできません</string>
     <string name="text_keyboard_layout_delete_key_confirm">このキーを削除しますか？</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -379,10 +379,17 @@
     <string name="text_keyboard_layout_macro_event_preview">%1$s → … (全 %2$d ステップ)</string>
     <string name="text_keyboard_layout_alt_label">代替ラベル</string>
     <string name="text_keyboard_layout_swipe_label">スワイプラベル</string>
+    <string name="text_keyboard_layout_switch_target">ターゲット</string>
+    <string name="text_keyboard_layout_switch_target_default">デフォルト（?123 / 前回の記号レイアウト）</string>
+    <string name="text_keyboard_layout_switch_target_text">テキストキーボード</string>
+    <string name="text_keyboard_layout_switch_target_number">数字キーボード</string>
+    <string name="text_keyboard_layout_switch_target_symbol">記号ピッカー</string>
+    <string name="text_keyboard_layout_numpad_symbol">テンキー記号</string>
     <string name="text_keyboard_layout_display_value_hint">表示値</string>
     <string name="text_keyboard_layout_key_label_caps">Caps</string>
     <string name="text_keyboard_layout_key_label_lang">Lang</string>
     <string name="text_keyboard_layout_key_label_space">Space</string>
+    <string name="text_keyboard_layout_key_label_minispace">␣</string>
     <string name="text_keyboard_layout_key_label_enter">Enter</string>
     <string name="space_key_label_mode">スペースキーのラベル表示</string>
     <string name="space_key_label_mode_default">デフォルト</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -356,6 +356,8 @@
     <string name="text_keyboard_layout_key_color_monet_unavailable">Monet の動的色は利用できません</string>
     <string name="text_keyboard_layout_layout_name">レイアウト名</string>
     <string name="text_keyboard_layout_layout_name_hint">例：rime、pinyin</string>
+    <string name="numeric_layout_override_title">数字入力のキーボードレイアウト</string>
+    <string name="numeric_layout_override_builtin">内蔵の数字キーボード</string>
     <string name="text_keyboard_layout_copy_from">既存レイアウトからコピー</string>
     <string name="text_keyboard_layout_name_empty">レイアウト名は空にできません</string>
     <string name="text_keyboard_layout_delete_key_confirm">このキーを削除しますか？</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -184,6 +184,7 @@
     <string name="text_keyboard_layout_layout_name_hint">예: rime, pinyin</string>
     <string name="numeric_layout_override_title">숫자 입력 키보드 레이아웃</string>
     <string name="numeric_layout_override_builtin">기본 숫자 키보드</string>
+    <string name="numeric_layout_override_unavailable">%1$s (현재 프로필에서 사용할 수 없음)</string>
     <string name="text_keyboard_layout_copy_from">기존 레이아웃에서 복사</string>
     <string name="text_keyboard_layout_name_empty">레이아웃 이름은 비워둘 수 없습니다</string>
     <string name="text_keyboard_layout_delete_key_confirm">이 키를 삭제하시겠습니까?</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -182,6 +182,8 @@
     <string name="text_keyboard_layout_key_color_monet_unavailable">Monet 동적 색상을 사용할 수 없습니다</string>
     <string name="text_keyboard_layout_layout_name">레이아웃 이름</string>
     <string name="text_keyboard_layout_layout_name_hint">예: rime, pinyin</string>
+    <string name="numeric_layout_override_title">숫자 입력 키보드 레이아웃</string>
+    <string name="numeric_layout_override_builtin">기본 숫자 키보드</string>
     <string name="text_keyboard_layout_copy_from">기존 레이아웃에서 복사</string>
     <string name="text_keyboard_layout_name_empty">레이아웃 이름은 비워둘 수 없습니다</string>
     <string name="text_keyboard_layout_delete_key_confirm">이 키를 삭제하시겠습니까?</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -199,6 +199,7 @@
     <string name="text_keyboard_layout_key_label_caps">Caps</string>
     <string name="text_keyboard_layout_key_label_lang">Lang</string>
     <string name="text_keyboard_layout_key_label_space">Space</string>
+    <string name="text_keyboard_layout_key_label_minispace">␣</string>
     <string name="text_keyboard_layout_key_label_enter">Enter</string>
     <string name="space_key_label_mode">스페이스 키 라벨 스타일</string>
     <string name="space_key_label_mode_default">기본값</string>
@@ -319,6 +320,12 @@
     <string name="text_keyboard_layout_macro_event_preview">%1$s → … (총 %2$d 단계)</string>
     <string name="text_keyboard_layout_alt_label">대체 레이블</string>
     <string name="text_keyboard_layout_swipe_label">스와이프 레이블</string>
+    <string name="text_keyboard_layout_switch_target">대상</string>
+    <string name="text_keyboard_layout_switch_target_default">기본 (?123 / 마지막 기호 레이아웃)</string>
+    <string name="text_keyboard_layout_switch_target_text">텍스트 키보드</string>
+    <string name="text_keyboard_layout_switch_target_number">숫자 키보드</string>
+    <string name="text_keyboard_layout_switch_target_symbol">기호 선택기</string>
+    <string name="text_keyboard_layout_numpad_symbol">숫자 패드 기호</string>
 
     <!-- Macro Editor -->
     <string name="macro_editor_title">%1$s 편집</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -425,6 +425,8 @@
     <string name="text_keyboard_layout_key_color_monet_unavailable">Динамический цвет Monet недоступен</string>
     <string name="text_keyboard_layout_layout_name">Имя раскладки</string>
     <string name="text_keyboard_layout_layout_name_hint">например: rime, pinyin</string>
+    <string name="numeric_layout_override_title">Раскладка клавиатуры для чисел</string>
+    <string name="numeric_layout_override_builtin">Встроенная цифровая клавиатура</string>
     <string name="text_keyboard_layout_copy_from">Скопировать из существующей раскладки</string>
     <string name="text_keyboard_layout_name_empty">Имя раскладки не может быть пустым</string>
     <string name="text_keyboard_layout_delete_key_confirm">Удалить эту клавишу?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -442,6 +442,7 @@
     <string name="text_keyboard_layout_key_label_caps">Caps</string>
     <string name="text_keyboard_layout_key_label_lang">Lang</string>
     <string name="text_keyboard_layout_key_label_space">Space</string>
+    <string name="text_keyboard_layout_key_label_minispace">␣</string>
     <string name="text_keyboard_layout_key_label_enter">Enter</string>
     <string name="space_key_label_mode">Стиль подписи клавиши пробела</string>
     <string name="space_key_label_mode_default">По умолчанию</string>
@@ -538,6 +539,12 @@
     <string name="text_keyboard_layout_macro_event_preview">%1$s → … (всего шагов: %2$d)</string>
     <string name="text_keyboard_layout_alt_label">Альтернативная метка</string>
     <string name="text_keyboard_layout_swipe_label">Метка свайпа</string>
+    <string name="text_keyboard_layout_switch_target">Цель</string>
+    <string name="text_keyboard_layout_switch_target_default">По умолчанию (?123 / последняя раскладка символов)</string>
+    <string name="text_keyboard_layout_switch_target_text">Текстовая клавиатура</string>
+    <string name="text_keyboard_layout_switch_target_number">Цифровая клавиатура</string>
+    <string name="text_keyboard_layout_switch_target_symbol">Выбор символов</string>
+    <string name="text_keyboard_layout_numpad_symbol">Символ цифровой клавиатуры</string>
 
     <!-- Macro Editor -->
     <string name="macro_editor_title">Редактировать %1$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -427,6 +427,7 @@
     <string name="text_keyboard_layout_layout_name_hint">например: rime, pinyin</string>
     <string name="numeric_layout_override_title">Раскладка клавиатуры для чисел</string>
     <string name="numeric_layout_override_builtin">Встроенная цифровая клавиатура</string>
+    <string name="numeric_layout_override_unavailable">%1$s (недоступно в текущем профиле)</string>
     <string name="text_keyboard_layout_copy_from">Скопировать из существующей раскладки</string>
     <string name="text_keyboard_layout_name_empty">Имя раскладки не может быть пустым</string>
     <string name="text_keyboard_layout_delete_key_confirm">Удалить эту клавишу?</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -605,6 +605,7 @@
     <string name="text_keyboard_layout_editing_default">正在编辑"%1$s"的默认布局</string>
     <string name="text_keyboard_layout_key_label_lang">Lang</string>
     <string name="text_keyboard_layout_key_label_space">Space</string>
+    <string name="text_keyboard_layout_key_label_minispace">␣</string>
     <string name="text_keyboard_layout_key_label_enter">Enter</string>
     <string name="text_keyboard_layout_alphabet_key_main_required">主字符不能为空</string>
     <string name="text_keyboard_layout_alphabet_key_alt_required">副字符不能为空</string>
@@ -621,6 +622,12 @@
     <string name="text_keyboard_layout_macro_event_preview">%1$s → … (共 %2$d 步)</string>
     <string name="text_keyboard_layout_alt_label">副标签</string>
     <string name="text_keyboard_layout_swipe_label">划动标签</string>
+    <string name="text_keyboard_layout_switch_target">目标</string>
+    <string name="text_keyboard_layout_switch_target_default">默认（?123 / 上次符号布局）</string>
+    <string name="text_keyboard_layout_switch_target_text">文本键盘</string>
+    <string name="text_keyboard_layout_switch_target_number">数字键盘</string>
+    <string name="text_keyboard_layout_switch_target_symbol">符号选择器</string>
+    <string name="text_keyboard_layout_numpad_symbol">数字键盘符号</string>
     <string name="text_keyboard_layout_validation_error">验证错误</string>
 
     <!-- Macro Editor -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -570,6 +570,8 @@
     <string name="text_keyboard_layout_key_color_monet_unavailable">当前设备不支持 Monet 动态颜色</string>
     <string name="text_keyboard_layout_layout_name">布局名称</string>
     <string name="text_keyboard_layout_layout_name_hint">例如：rime、pinyin</string>
+    <string name="numeric_layout_override_title">数字键盘布局</string>
+    <string name="numeric_layout_override_builtin">内置数字键盘</string>
     <string name="text_keyboard_layout_copy_from">从现有布局复制</string>
     <string name="text_keyboard_layout_name_empty">布局名称不能为空</string>
     <string name="text_keyboard_layout_delete_key_confirm">删除这个按键？</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -572,6 +572,7 @@
     <string name="text_keyboard_layout_layout_name_hint">例如：rime、pinyin</string>
     <string name="numeric_layout_override_title">数字键盘布局</string>
     <string name="numeric_layout_override_builtin">内置数字键盘</string>
+    <string name="numeric_layout_override_unavailable">%1$s（当前配置中不可用）</string>
     <string name="text_keyboard_layout_copy_from">从现有布局复制</string>
     <string name="text_keyboard_layout_name_empty">布局名称不能为空</string>
     <string name="text_keyboard_layout_delete_key_confirm">删除这个按键？</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -486,6 +486,7 @@
     <string name="text_keyboard_layout_key_label_caps">Caps</string>
     <string name="text_keyboard_layout_key_label_lang">Lang</string>
     <string name="text_keyboard_layout_key_label_space">Space</string>
+    <string name="text_keyboard_layout_key_label_minispace">␣</string>
     <string name="text_keyboard_layout_key_label_enter">Enter</string>
     <string name="text_keyboard_layout_alphabet_key_main_required">主字元不能為空</string>
     <string name="text_keyboard_layout_alphabet_key_alt_required">副字元不能為空</string>
@@ -601,6 +602,12 @@
     <string name="text_keyboard_layout_macro_event_preview">%1$s → … (共 %2$d 步)</string>
     <string name="text_keyboard_layout_alt_label">副標籤</string>
     <string name="text_keyboard_layout_swipe_label">劃動標籤</string>
+    <string name="text_keyboard_layout_switch_target">目標</string>
+    <string name="text_keyboard_layout_switch_target_default">預設（?123 / 上次符號佈局）</string>
+    <string name="text_keyboard_layout_switch_target_text">文字鍵盤</string>
+    <string name="text_keyboard_layout_switch_target_number">數字鍵盤</string>
+    <string name="text_keyboard_layout_switch_target_symbol">符號選擇器</string>
+    <string name="text_keyboard_layout_numpad_symbol">數字鍵盤符號</string>
 
     <!-- Macro Editor -->
     <string name="macro_editor_title">編輯 %1$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -469,6 +469,7 @@
     <string name="text_keyboard_layout_layout_name_hint">例如：rime、pinyin</string>
     <string name="numeric_layout_override_title">數字鍵盤佈局</string>
     <string name="numeric_layout_override_builtin">內建數字鍵盤</string>
+    <string name="numeric_layout_override_unavailable">%1$s（目前設定中不可用）</string>
     <string name="text_keyboard_layout_layout_name_exists">佈局名稱已存在</string>
     <string name="text_keyboard_layout_copy_from">從現有佈局複製</string>
     <string name="text_keyboard_layout_name_empty">佈局名稱不能為空</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -467,6 +467,8 @@
     <string name="text_keyboard_layout_key_color_monet_unavailable">Monet 動態顏色目前不可用</string>
     <string name="text_keyboard_layout_layout_name">佈局名稱</string>
     <string name="text_keyboard_layout_layout_name_hint">例如：rime、pinyin</string>
+    <string name="numeric_layout_override_title">數字鍵盤佈局</string>
+    <string name="numeric_layout_override_builtin">內建數字鍵盤</string>
     <string name="text_keyboard_layout_layout_name_exists">佈局名稱已存在</string>
     <string name="text_keyboard_layout_copy_from">從現有佈局複製</string>
     <string name="text_keyboard_layout_name_empty">佈局名稱不能為空</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -582,6 +582,8 @@
     <string name="text_keyboard_layout_key_color_monet_unavailable">Monet dynamic color is unavailable on this device</string>
     <string name="text_keyboard_layout_layout_name">Layout Name</string>
     <string name="text_keyboard_layout_layout_name_hint">e.g., rime, pinyin</string>
+    <string name="numeric_layout_override_title">Numeric keyboard layout</string>
+    <string name="numeric_layout_override_builtin">Built-in number keypad</string>
     <string name="text_keyboard_layout_copy_from">Copy from existing layout</string>
     <string name="text_keyboard_layout_name_empty">Layout name cannot be empty</string>
     <string name="text_keyboard_layout_delete_key_confirm">Delete this key?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -584,6 +584,7 @@
     <string name="text_keyboard_layout_layout_name_hint">e.g., rime, pinyin</string>
     <string name="numeric_layout_override_title">Numeric keyboard layout</string>
     <string name="numeric_layout_override_builtin">Built-in number keypad</string>
+    <string name="numeric_layout_override_unavailable">%1$s (unavailable in current profile)</string>
     <string name="text_keyboard_layout_copy_from">Copy from existing layout</string>
     <string name="text_keyboard_layout_name_empty">Layout name cannot be empty</string>
     <string name="text_keyboard_layout_delete_key_confirm">Delete this key?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -606,10 +606,17 @@
     <string name="text_keyboard_layout_macro_event_preview">%1$s → … (%2$d steps total)</string>
     <string name="text_keyboard_layout_alt_label">Alt Label</string>
     <string name="text_keyboard_layout_swipe_label">Swipe Label</string>
+    <string name="text_keyboard_layout_switch_target">Target</string>
+    <string name="text_keyboard_layout_switch_target_default">Default (?123 / last symbol layout)</string>
+    <string name="text_keyboard_layout_switch_target_text">Text keyboard</string>
+    <string name="text_keyboard_layout_switch_target_number">Number keyboard</string>
+    <string name="text_keyboard_layout_switch_target_symbol">Symbol picker</string>
+    <string name="text_keyboard_layout_numpad_symbol">Numpad Symbol</string>
     <string name="text_keyboard_layout_display_value_hint">Display value</string>
     <string name="text_keyboard_layout_key_label_caps">Caps</string>
     <string name="text_keyboard_layout_key_label_lang">Lang</string>
     <string name="text_keyboard_layout_key_label_space">Space</string>
+    <string name="text_keyboard_layout_key_label_minispace">␣</string>
     <string name="text_keyboard_layout_key_label_enter">Enter</string>
     <string name="text_keyboard_layout_alphabet_key_main_required">Main character must not be empty</string>
     <string name="text_keyboard_layout_alphabet_key_alt_required">Alt character must not be empty</string>

--- a/codegen/src/main/java/org/fcitx/fcitx5/android/codegen/GenKeyMapping.kt
+++ b/codegen/src/main/java/org/fcitx/fcitx5/android/codegen/GenKeyMapping.kt
@@ -180,6 +180,8 @@ internal class GenKeyMappingProcessor(private val environment: SymbolProcessorEn
         "KP_Enter" to 0xff8d to "KEYCODE_NUMPAD_ENTER",
         "KP_0" to 0xffb0 to "KEYCODE_NUMPAD_0",
         "KP_Decimal" to 0xffae to "KEYCODE_NUMPAD_DOT",
+        "KP_Separator" to 0xffac to "KEYCODE_NUMPAD_COMMA",
+        "KP_Equal" to 0xffbd to "KEYCODE_NUMPAD_EQUALS",
 
         "Eisu_toggle" to 0xff30 to "KEYCODE_EISU", // FcitxKey_Eisu_toggle
         "Kana_Lock" to 0xff2d to "KEYCODE_KANA", // FcitxKey_Kana_Lock


### PR DESCRIPTION
## 概述

本 PR 完善数字输入场景的自定义键盘能力，覆盖：

- 从当前 TextKeyboard 布局文件中选择自定义数字输入布局；
- 自定义数字键、迷你空格键与布局切换目标的可视化编辑；
- 手动数字键盘、MacroKey 层切换、LayoutSwitchKey、BACK 层历史之间的状态一致性；
- 模拟数字键盘与物理小键盘的 `KP_*` keysym 语义保留；
- NumPadKey / MiniSpaceKey 的颜色和空格滑动游标行为。

---

## 1. 数字输入布局选择

在 **键盘设置 → 编辑器** 中新增「数字键盘布局」设置项。

点击后显示单选列表：

1. **内置数字键盘**：默认值，保持原 `NumberKeyboard` / T9 行为；
2. 当前启用的 TextKeyboard 布局文件中的所有可用层：
   - 基础布局，如 `default`、`数字`、`符号`、`rime`；
   - 子模式布局，如 `rime:wanxiang`。

层列表复用 `LayoutDataManager.parseJsonText` 的解析结果，与布局编辑页的布局/子模式选择逻辑一致，不另起 JSON 解析实现。

选择自定义层后，`TYPE_CLASS_NUMBER` / `TYPE_CLASS_PHONE` 输入框会短路内置数字键盘，直接显示所选 TextKeyboard 布局层；留空、层被删除、布局文件切换或配置无效时，自动回退到内置数字键盘。

PIN 数字密码框同样支持该能力，同时继续通过 `Password` capability flag 清空候选栏，与文本密码框保持一致。

---

## 2. 状态解耦与失效回退

新增 `NumericLayoutOverrideController`，将数字布局 override 的会话状态从 `TextKeyboard` 的布局解析逻辑中拆出：

- `sessionKey`：当前数字输入会话绑定的 override 层；
- `forcedKey`：当前实际强制显示的层；
- `manual`：文本输入会话中用户手动切入数字布局的状态。

TextKeyboard 仍只负责渲染和应用当前 forced layer，布局文件仍只定义 TextKeyboard 层数据；数字输入布局选择仅存在于应用设置，避免在 `TextKeyboardLayout.json` 中混入非布局职责的数据结构。

布局文件、布局 profile 或 Web 编辑器内存布局源变化时，会重新校验当前 override；已失效的层自动丢弃并回退到内置数字键盘。

---

## 3. LayoutSwitchKey 与 MacroKey 层切换

### 数字键盘切换目标

`LayoutSwitchKey` 目标为 `Number` 时，无论入口来自：

- 数字输入框自动唤起；
- 文本键盘上的 LayoutSwitchKey；
- 符号面板的小键盘按钮；
- 预设按键或宏按键；

都会统一检查当前「数字键盘布局」设置，并在可用时显示自定义数字输入布局。

### 显式返回文本键盘

用户通过 `LayoutSwitchKey(target = Text)` 明确切回文本键盘时：

- 清空 `TO` / `OSL` 锁存层；
- 清空 BACK 层历史；
- 释放当前数字 override 或手动数字布局；
- 回到正常文本主键盘。

### 修复层切换被冲掉的问题

修复两个相邻但不同的状态问题：

1. MacroKey 切层后，Text 目标 LayoutSwitchKey 之前因当前已经是 `TextKeyboard` 而走 early-return，锁存层未被清除，ABC 类按键看起来无效；
2. 用户先手动通过 LayoutSwitchKey 进入数字布局后，MacroKey `TO` / `OSL` 切到 `数字`、`符号`、`rime` 等层时，内部 Text→Text 重排错误调用 `releaseManualNumericLayout()`，导致刚锁存的层被重置为文本主键盘。

现在：

- 内部层重排、OSL 消费、输入重启不会错误释放手动数字布局；
- 只有显式用户按键切回 Text 时才释放；
- BACK 层历史在输入重启和显式返回文本键盘时清空，避免恢复陈旧层。

---

## 4. 数字键与布局编辑能力

### NumPadKey

新增 `NumPadKey` 类型及「数字符号」下拉选项：

- `0` ~ `9`
- `+`、`-`、`*`、`/`
- `,`、`.`、`=`

JSON 使用规范 Fcitx 键名保存 `sym`，例如：

```json
{
  "type": "NumPadKey",
  "label": "2",
  "sym": "KP_2"
}
```

导入时兼容：

- 规范键名：`KP_2`；
- 大小写不敏感名称：`kp_2`；
- 十进制 keysym；
- `0x...` / `#...` 十六进制 keysym；
- 符号标签：`2`、`+`、`,`、`.` 等；
- 仅含 `label` 的旧/手写 NumPadKey JSON（例如 `{ "type": "NumPadKey", "label": "2" }`）会正确解析为 `KP_2`，不会被静默重置为 `KP_0`。

### MiniSpaceKey

新增 `MiniSpaceKey` 编辑支持，默认宽度为 `0.15`，预览和编辑列表按迷你空格键显示。

### LayoutSwitchKey

新增「切换目标」下拉，保存到 `subLabel`：

- 默认 `?123` 符号面板；
- `Text` 文本键盘；
- `Number` 数字键盘；
- `Symbol` 符号面板。

---

## 5. 颜色与空格手势

### NumPadKey / MiniSpaceKey 颜色

修复编辑器保存了颜色字段、但运行时未传入 `Appearance` 的问题。

以下 JSON 字段现在对两类按键实际生效：

- `textColor` / `textColorMonet`
- `backgroundColor` / `backgroundColorMonet`
- `shadowColor` / `shadowColorMonet`

`keyDefToJson` 原有的 Appearance → JSON 序列化逻辑保持不变，因此导入、编辑、保存的 round-trip 一致。

`altTextColor` 不对这两类键伪支持：`NumPadKey` 是单一文字按键，`MiniSpaceKey` 是图标按键，二者均没有副文字的渲染目标。

### MiniSpaceKey 空格滑动

`MiniSpaceKey` 现在复用普通 `SpaceKey` 的完整滑动游标逻辑：

- 受 `space_swipe_move_cursor` 设置控制；
- 支持左右/上下方向移动、重复移动、阈值和震动反馈；
- 新建 KeyView 与缓存行复用路径行为一致。

---

## 6. 小键盘 keysym 一致性

### 模拟小键盘

模拟 `KP_*` 键时始终携带 `META_NUM_LOCK_ON`，避免 Android `KeyCharacterMap` 将数字小键盘键解释为导航键。

同时补齐：

- `KP_Separator` ↔ `KEYCODE_NUMPAD_COMMA`
- `KP_Equal` ↔ `KEYCODE_NUMPAD_EQUALS`

的 Fcitx / Android 双向映射。

### 物理小键盘

`KeySym.fromKeyEvent` 现在优先识别 Android 物理小键盘 keyCode：

- `NUMPAD_0` ~ `NUMPAD_9`
- `NUMPAD_ENTER`
- `NUMPAD_ADD` / `SUBTRACT` / `MULTIPLY` / `DIVIDE`
- `NUMPAD_DOT` / `COMMA` / `EQUALS`

并保留为对应的 `KP_*` keysym，不会因 Android 同时提供普通 Unicode 字符（如 `0`、`.`）而把物理小键盘错误降级为普通字符键。

自定义数字键、模拟数字键和物理数字键三条路径保持一致的 Fcitx keysym 语义。

---

## 验证

- 已基于最新 `fx` 上游提交变基；
- PR 当前无冲突；
- 已完成设备测试，覆盖：数字输入布局选择、PIN 密码框、LayoutSwitchKey → Number / Text、MacroKey `TO` / `OSL` / `BACK` 层切换、NumPadKey、MiniSpaceKey、颜色覆盖、MiniSpace 滑动游标及物理小键盘 keysym。