### PR TITLE
fix(Kawaii Bar): 修复宏按键输入和扩展窗口切换时的异常高亮

### DIFF
--- a/app/src/main/java/org/fcitx/fcitx5/android/input/FcitxInputMethodService.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/FcitxInputMethodService.kt
@@ -1349,6 +1349,10 @@ class FcitxInputMethodService : LifecycleInputMethodService() {
         Timber.v("sendSimulatedKeyEvent: keyCode=%d scanCode=%d action=%d unicodeChar=%d",
             keyCode, scanCode, action, event.unicodeChar)
         forwardKeyEvent(event, preserveModifierState = true)
+        if (fromMacro) {
+            inputView?.clearKawaiiBarFocusState()
+            inputView?.post { inputView?.clearKawaiiBarFocusState() }
+        }
 
         if (action == KeyEvent.ACTION_UP) {
             when (keyCode) {

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/InputView.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/InputView.kt
@@ -3340,6 +3340,10 @@ class InputView(
         broadcaster.onSelectionUpdate(start, end)
     }
 
+    internal fun clearKawaiiBarFocusState() {
+        kawaiiBar.clearFocusState()
+    }
+
     /**
      * Control whether the preedit component should display preedit text.
      * Set to false when preedit is displayed elsewhere (e.g., in floating CandidatesView).

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/bar/KawaiiBarComponent.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/bar/KawaiiBarComponent.kt
@@ -132,6 +132,16 @@ class KawaiiBarComponent : UniqueViewComponent<KawaiiBarComponent, FrameLayout>(
         idleUi.buttonsUi.refreshLayout()
     }
 
+    /**
+     * Macro-simulated key events can move focus out of touch mode. Clear any
+     * stale focus from toolbar descendants before Android renders a focus highlight.
+     */
+    fun clearFocusState() {
+        view.clearFocus()
+        idleUi.root.clearFocus()
+        idleUi.buttonsUi.root.clearFocus()
+    }
+
     private val prefs = AppPrefs.getInstance()
 
     private val clipboardSuggestion = prefs.clipboard.clipboardSuggestion
@@ -716,6 +726,9 @@ class KawaiiBarComponent : UniqueViewComponent<KawaiiBarComponent, FrameLayout>(
 
     override val view by lazy {
         ViewAnimator(context).apply {
+            isFocusable = false
+            isFocusableInTouchMode = false
+            descendantFocusability = ViewGroup.FOCUS_BLOCK_DESCENDANTS
             backgroundColor =
                 if (ThemeManager.prefs.keyBorder.getValue()) Color.TRANSPARENT
                 else theme.barColor

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/bar/KawaiiBarComponent.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/bar/KawaiiBarComponent.kt
@@ -715,6 +715,14 @@ class KawaiiBarComponent : UniqueViewComponent<KawaiiBarComponent, FrameLayout>(
     private fun switchUiByState(state: KawaiiBarStateMachine.State) {
         val index = state.ordinal
         if (view.displayedChild == index) return
+        if (
+            view.displayedChild == KawaiiBarStateMachine.State.Idle.ordinal &&
+            state == KawaiiBarStateMachine.State.Title
+        ) {
+            // An extended window replaces IdleUi immediately. End its unbounded button
+            // ripples before the title bar is drawn in the same region.
+            idleUi.clearTransientPressState()
+        }
         val new = view.getChildAt(index)
         if (new != titleUi.root) {
             titleUi.setReturnButtonOnClickListener { }

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/bar/ui/IdleUi.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/bar/ui/IdleUi.kt
@@ -206,6 +206,12 @@ class IdleUi(
         add(numberRow, lParams(matchParent, matchParent))
     }
 
+    fun clearTransientPressState() {
+        menuButton.clearTransientPressState()
+        hideKeyboardButton.clearTransientPressState()
+        buttonsUi.clearTransientPressState()
+    }
+
     fun privateMode(activate: Boolean = true) {
         if (activate == inPrivate) return
         inPrivate = activate

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/bar/ui/ToolButton.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/bar/ui/ToolButton.kt
@@ -80,6 +80,14 @@ class ToolButton(context: Context) : CustomGestureView(context) {
 
     fun iconAnimate(): ViewPropertyAnimator = image.animate()
 
+    /**
+     * End a touch ripple before this button's containing UI is replaced.
+     */
+    fun clearTransientPressState() {
+        cancelGestures()
+        jumpDrawablesToCurrentState()
+    }
+
     fun setIcon(@DrawableRes icon: Int) {
         usingCustomDrawable = false
         textView.visibility = View.GONE

--- a/app/src/main/java/org/fcitx/fcitx5/android/input/bar/ui/idle/ButtonsBarUi.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/bar/ui/idle/ButtonsBarUi.kt
@@ -175,6 +175,10 @@ class ButtonsBarUi(
 
     fun getButton(buttonId: String): ToolButton? = buttonMap[buttonId]
 
+    fun clearTransientPressState() {
+        buttonMap.values.forEach { it.clearTransientPressState() }
+    }
+
     fun setFloatingState(isFloating: Boolean) {
         buttonActiveMap["floating_toggle"] = isFloating
         buttonMap["floating_toggle"]?.setActive(isFloating)


### PR DESCRIPTION
## 问题描述

本 PR 修复 Kawaii Bar 在以下两种场景下出现的异常高亮问题。

### 1. macrokey 输入后的错误高亮

在自定义键盘布局中使用 `macrokey`，并通过 Fcitx `Tap` 动作直接输入字符时，字符可以正常上屏，但 Kawaii Bar 偶尔会错误地保持选中样式。

例如，使用 macrokey 直接输入数字后：

- 数字可以正常输入到目标编辑框。
- Kawaii Bar 可能保持工具栏按钮被选中的颜色。
- 收起再展开工具栏后，颜色才会恢复正常。

相关事件路径为：

```text
MacroStep$Tap
-> sendSimulatedKeyEvent
-> forwardKeyEvent
-> Fcitx KeyEvent
```

该路径不会产生对应的预编辑或候选更新事件。

### 2. 扩展窗口切换时的按压高亮闪烁

点击 Kawaii Bar 中会打开扩展窗口的按钮时，例如状态区、文本编辑或剪贴板按钮，Kawaii Bar 会从 `Idle` 切换到 `Title`。

在部分设备和特定时序下，左侧工具栏按钮可能会短暂显示一次按压高亮，看起来像是左侧按钮被点击。

该问题并不只发生在某一个按钮，而是可能出现在多个会打开扩展窗口的工具栏操作中。

## 问题原因

宏模拟按键事件可能会让 Android 离开触摸模式。随后 Android 对 Kawaii Bar 的视图层级执行焦点搜索，导致工具栏按钮残留异步产生的焦点状态。

虽然 `CustomGestureView` 已经禁止单个手势按钮获取焦点，但 Kawaii Bar 的容器及其后代视图仍可能保留焦点状态。

另一方面，工具栏按钮使用 `RippleDrawable`。按钮被点击后，按压 ripple 的退出过程可能与 `Idle -> Title` 的界面切换重叠，使即将离开的工具栏按钮保留短暂的按压绘制状态。

## 修改内容

- 宏模拟按键发送后立即清理 Kawaii Bar 的焦点状态。
- 在下一次 UI 消息循环中再次清理焦点，处理 Android 异步焦点更新。
- 通过 `InputView` 增加 Kawaii Bar 焦点清理入口。
- 清理 Kawaii Bar、Idle UI 以及工具栏按钮容器的焦点。
- 将 Kawaii Bar 的 `ViewAnimator` 设置为不可聚焦。
- 阻止 Kawaii Bar 的后代视图参与焦点导航。
- 在所有 `Idle -> Title` 状态切换前，清理 Idle 工具栏按钮的 transient 按压状态。
- 在界面切换前立即结束未完成的 ripple 绘制。

## 修改范围

本 PR 只包含 Kawaii Bar 的以下修复：

- macrokey 模拟输入后的焦点高亮修复。
- 扩展窗口切换时的按压 ripple 高亮修复。

## 测试情况

使用包含 macrokey 输入动作的自定义键盘布局进行测试，并重复执行以下操作：

- 使用 macrokey 输入数字和其他字符。
- 打开和关闭状态区窗口。
- 打开和关闭文本编辑窗口。
- 打开和关闭剪贴板窗口。
- 重复点击会打开扩展窗口的工具栏按钮。

预期结果：

- macrokey 字符可以正常输入到目标编辑框。
- macrokey 输入后 Kawaii Bar 保持正常颜色。
- 打开扩展窗口时，左侧工具栏不会错误显示按压高亮。
- 不需要收起再展开工具栏即可恢复正常显示。
- 不会影响原有工具栏按钮的点击和手势操作。