### PR TITLE
fix(键盘状态): 修复输入重置后合成中按键状态残留

### DIFF
--- a/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
+++ b/app/src/main/java/org/fcitx/fcitx5/android/input/keyboard/KeyboardWindow.kt
@@ -455,7 +455,8 @@ class KeyboardWindow : InputWindow.SimpleInputWindow<KeyboardWindow>(), Essentia
         noConfigAuxBarFallbackActive = false
         preeditEmpty = true
         candidateEmpty = true
-        composingState = false
+        // Let updateCompositionState notify the active keyboard as well. Resetting
+        // composingState directly can leave compose-aware keys in their old view.
         val inputClass = info.inputType and InputType.TYPE_MASK_CLASS
         val isNumericClass = inputClass == InputType.TYPE_CLASS_NUMBER ||
             inputClass == InputType.TYPE_CLASS_PHONE


### PR DESCRIPTION
## 问题

键盘布局中的按键可以配置“合成中按键”外观。正常输入并上屏后，编辑状态结束，按键应恢复为原始按键。

在输入文字并触发预测后点击聊天框发送时，输入框、预测状态和候选栏都会被清空。但收起键盘后再次打开，部分按键仍显示为合成中按键，只有再次输入并手动清空编辑状态后才会恢复。

## 原因

`KeyboardWindow.onStartInput()` 清空 `preeditEmpty` 和 `candidateEmpty` 后，又直接把 `composingState` 设置为 `false`。

随后 `updateCompositionState()` 计算出的状态也是 `false`，状态比较会直接返回，因此不会调用 `BaseKeyboard.onCompositionStateChanged(false)`。

这导致 `KeyboardWindow` 的状态已经清空，但 `BaseKeyboard` 内部仍保留旧的合成状态，配置了合成中按键的按键外观因此残留。

## 修复

移除 `onStartInput()` 中对 `composingState` 的直接赋值，让 `updateCompositionState()` 统一检测状态变化并通知当前键盘。

输入状态重置时，键盘现在可以正确从合成状态切换回非合成状态，相关按键也会恢复为原始定义。

## 变更范围

- 已基于 `fxliang/fx` 最新提交重新整理。
- 相对目标分支仅包含一个修复提交。
- 仅修改 `KeyboardWindow.kt`。